### PR TITLE
Various platform updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,15 @@ jobs:
     strategy:
       matrix:
         os:
-          - amazonlinux-2
-          - amazonlinux-2022
+          - almalinux-8
+          - almalinux-9
+          - amazonlinux-2023
           - centos-7
           - centos-stream-8
           - centos-stream-9
-          - debian-9
           - debian-10
           - debian-11
+          - debian-12
           - opensuse-leap-15
           - ubuntu-1804
           - ubuntu-2004

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,28 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Add support for ppc64le on Debian & Ubuntu
+- Add support for:
+  - AlmaLinux 8 & 9
+  - Amazon Linux 2023
+  - Debian 12
+- Remove support for:
+  - Amazon Linux 2 & 2022
+  - Debian 9
+- Set sane default for Windows System Drive
+- Update and improved unit and integration tests
+
 ## 1.0.4 - *2023-05-03*
+
+- Update sous-chefs/.github action to v2.0.2
 
 ## 1.0.3 - *2023-04-01*
 
+- Update actions/stale action to v8
+
 ## 1.0.2 - *2023-03-02*
+
+- Fix yaml
 
 ## 1.0.1 - *2022-10-20*
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,14 +15,15 @@ verifier:
     - path: test/integration/cinc-omnibus
 
 platforms:
-  - name: amazonlinux-2
-  - name: amazonlinux-2022
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
   - name: centos-7
   - name: centos-stream-8
   - name: centos-stream-9
-  - name: debian-9
   - name: debian-10
   - name: debian-11
+  - name: debian-12
   - name: opensuse-leap-15
   - name: ubuntu-18.04
   - name: ubuntu-20.04

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,15 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package omnibus_packages
+package omnibus_packages if omnibus_packages
 
 build_essential 'cinc-omnibus'
 
 chef_ingredient 'omnibus-toolchain' do
-  # Chef doesn't have EL9 on ppc64le yet
-  if ppc64le? && el? && node['platform_version'].to_i == 9
-    rubygems_url 'https://packagecloud.io/cinc-project/stable'
-  end
+  # Chef doesn't have some platforms on ppc64le yet
+  rubygems_url 'https://packagecloud.io/cinc-project/stable' if cinc_omnibus?
   version 'latest'
   channel :stable
   architecture node['kernel']['machine']

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -19,23 +19,119 @@
 require 'spec_helper'
 
 describe 'cinc-omnibus::default' do
-  context 'When all attributes are default, on Ubuntu' do
-    # for a complete list of available platforms and versions see:
-    # https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
+  context 'ubuntu' do
     platform 'ubuntu'
 
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
+    it { expect { chef_run }.to_not raise_error }
+
+    it do
+      is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+        rubygems_url: nil,
+        version: 'latest',
+        channel: :stable,
+        architecture: 'x86_64',
+        platform: nil,
+        platform_version_compatibility_mode: true
+      )
+    end
+
+    context 'ubuntu - ppc64le' do
+      automatic_attributes['kernel']['machine'] = 'ppc64le'
+
+      it { expect { chef_run }.to_not raise_error }
+      it do
+        is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+          rubygems_url: 'https://packagecloud.io/cinc-project/stable',
+          version: 'latest',
+          channel: :stable,
+          architecture: 'ppc64le',
+          platform: nil,
+          platform_version_compatibility_mode: true
+        )
+      end
     end
   end
 
-  context 'When all attributes are default, on CentOS' do
-    # for a complete list of available platforms and versions see:
-    # https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
-    platform 'centos'
+  context 'opensuse' do
+    platform 'opensuse'
 
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
+    it { expect { chef_run }.to_not raise_error }
+    it do
+      is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+        rubygems_url: nil,
+        version: 'latest',
+        channel: :stable,
+        architecture: 'x86_64',
+        platform: 'sles',
+        platform_version_compatibility_mode: true
+      )
     end
   end
+
+  context 'windows' do
+    platform 'windows'
+
+    it { expect { chef_run }.to_not raise_error }
+    it do
+      is_expected.to install_chef_ingredient('omnibus-toolchain').with(
+        rubygems_url: nil,
+        version: 'latest',
+        channel: :stable,
+        architecture: 'x86_64',
+        platform: nil,
+        platform_version_compatibility_mode: true
+      )
+    end
+  end
+
+  context 'debian - ppc64le' do
+    platform 'debian'
+    automatic_attributes['kernel']['machine'] = 'ppc64le'
+
+    it { expect { chef_run }.to_not raise_error }
+    it do
+      is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+        rubygems_url: 'https://packagecloud.io/cinc-project/stable',
+        version: 'latest',
+        channel: :stable,
+        architecture: 'ppc64le',
+        platform: nil,
+        platform_version_compatibility_mode: true
+      )
+    end
+  end
+
+  context 'almalinux 8 - ppc64le' do
+    platform 'almalinux', '8'
+    automatic_attributes['kernel']['machine'] = 'ppc64le'
+
+    it { expect { chef_run }.to_not raise_error }
+    it do
+      is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+        rubygems_url: nil,
+        version: 'latest',
+        channel: :stable,
+        architecture: 'ppc64le',
+        platform: nil,
+        platform_version_compatibility_mode: true
+      )
+    end
+  end
+
+  # TODO: Uncomment when latest fauxhai-ng is released
+  # context 'almalinux 9 - ppc64le' do
+  #   platform 'almalinux', '9'
+  #   automatic_attributes['kernel']['machine'] = 'ppc64le'
+  #
+  #   it do
+  #     is_expected.to upgrade_chef_ingredient('omnibus-toolchain').with(
+  #       rubygems_url: 'https://packagecloud.io/cinc-project/stable',
+  #       version: 'latest',
+  #       channel: :stable,
+  #       architecture: 'ppc64le',
+  #       platform: nil,
+  #       platform_version_compatibility_mode: true
+  #     )
+  #   end
+  # end
 end

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -1,4 +1,5 @@
 os_version = os.release
+path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 control 'default' do
   case os.name
@@ -15,7 +16,7 @@ control 'default' do
       tzdata
       wget
     )
-  when 'centos', 'redhat'
+  when 'centos', 'redhat', 'almalinux'
     packages = %w(
       automake
       bzip2
@@ -94,5 +95,25 @@ control 'default' do
   describe command '/home/omnibus/load-omnibus-toolchain.sh' do
     its('exit_status') { should eq 0 }
     its('stderr') { should eq '' }
+  end
+
+  [
+    'bash --version',
+    'berks --version',
+    'bundle --version',
+    'curl --version',
+    'gcc --version',
+    'gem --version',
+    'git --version',
+    'java -version',
+    'make --version',
+    'patch --version',
+    'pkg-config --version',
+    'ruby --version',
+    'tar --version',
+  ].each do |cmd|
+    describe command "PATH='/opt/omnibus-toolchain/bin:/usr/local/bin:#{path}' #{cmd}" do
+      its('exit_status') { should eq 0 }
+    end
   end
 end


### PR DESCRIPTION
- Add support for ppc64le on Debian & Ubuntu
- Add support for:
  - AlmaLinux 8 & 9
  - Amazon Linux 2023
  - Debian 12
- Remove support for:
  - Amazon Linux 2 & 2022
  - Debian 9
- Set sane default for Windows System Drive
- Update and improved unit and integration tests

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
