### PR TITLE
Add fixes for missing install path for Debian 11 and older on AArch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Add fixes for missing install path for Debian 11 and older on AArch64
+
 ## 1.1.4 - *2023-09-11*
+
+- Update actions/checkout action to v4 (#12)
 
 ## 1.1.3 - *2023-08-21*
 
@@ -12,7 +16,11 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## 1.1.2 - *2023-07-10*
 
+- Update sous-chefs/.github action to v2.0.5 (#10)
+
 ## 1.1.1 - *2023-05-16*
+
+- Update sous-chefs/.github action to v2.0.4 (#9)
 
 ## 1.1.0 - *2023-05-03*
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,9 +138,15 @@ end
 
 cookbook_file '/usr/local/share/ruby-docker-copy-patch.rb'
 
-# Fix a problem only on Debian 11 and older on ARM which results in:
+# Fix problems only on Debian 11 and older on ARM which results in:
 # make: /usr/bin/mkdir: No such file or directory
-link '/usr/bin/mkdir' do
-  to '/bin/mkdir'
-  only_if { arm? && debian_platform? && node['platform_version'].to_i < 12 }
+# make: /usr/bin/install: No such file or directory
+if arm? && debian_platform? && node['platform_version'].to_i < 12
+  link '/usr/bin/mkdir' do
+    to '/bin/mkdir'
+  end
+
+  link '/usr/bin/install' do
+    to '/bin/install'
+  end
 end


### PR DESCRIPTION
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
