### PR TITLE
Ensure "unsafe" development packages are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Ensure "unsafe" development packages are removed
+
 ## 1.1.6 - *2023-09-21*
 
 - Use correct linking for install path

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -128,6 +128,15 @@ module CincOmnibus
         end
       end
 
+      def omnibus_unsafe_deps
+        case node['platform_family']
+        when 'amazon', 'rhel', 'fedora', 'suse'
+          %w(pcre2-devel libselinux-devel)
+        when 'debian'
+          %w(libpcre2-dev libselinux1-dev)
+        end
+      end
+
       def omnibus_env
         node.run_state[:omnibus_env] ||= Hash.new { |hash, key| hash[key] = [] }
       end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,10 @@ package omnibus_packages if omnibus_packages
 
 build_essential 'cinc-omnibus'
 
+package omnibus_unsafe_deps do
+  action :remove
+end if omnibus_unsafe_deps
+
 chef_ingredient 'omnibus-toolchain' do
   # Chef doesn't have some platforms on ppc64le yet
   rubygems_url 'https://packagecloud.io/cinc-project/stable' if cinc_omnibus?

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -78,9 +78,22 @@ control 'default' do
     )
   end
 
+  case os.family
+  when 'amazon', 'redhat', 'fedora', 'suse'
+    unsafe_pkgs = %w(pcre2-devel libselinux-devel)
+  when 'debian'
+    unsafe_pkgs = %w(libpcre2-dev libselinux1-dev)
+  end
+
   packages.flatten.sort.each do |pkg|
     describe package pkg do
       it { should be_installed }
+    end
+  end
+
+  unsafe_pkgs.each do |pkg|
+    describe package pkg do
+      it { should_not be_installed }
     end
   end
 


### PR DESCRIPTION
It appears that EL8 installs openssl-devel as a "weak" dependency which also
pulls in libselinux-devel and libpcre2-devel. When building Cinc Server, this
becomes an issue when building logrotate as it tries to link against those
installed dependencies, instead of what's included in the omnibus build
environment.

This ensures that those weak dependencies are not present. It doesn't seem to
affect the other platforms, but I included them here too to be safe.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
