### PR TITLE
Ensure Perl IPC-Cmd is installed on EL based systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Ensure Perl IPC-Cmd is installed on EL based systems which is required for building OpenSSL v3
+
 ## 1.1.9 - *2023-10-31*
 
 ## 1.1.8 - *2023-10-16*

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,6 +17,7 @@ module CincOmnibus
             libffi-devel
             ncurses-devel
             openssh-clients
+            perl-IPC-Cmd
             rpm-build
             rpm-sign
             rsync
@@ -35,6 +36,7 @@ module CincOmnibus
             iproute
             libffi-devel
             openssh-clients
+            perl-IPC-Cmd
             rpm-build
             rpm-sign
             rsync

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -11,6 +11,7 @@ control 'default' do
       glibc-locale-source
       iproute
       openssh-clients
+      perl-IPC-Cmd
       rsync
       tar
       tzdata
@@ -24,6 +25,7 @@ control 'default' do
       iproute
       libffi-devel
       openssh-clients
+      perl-IPC-Cmd
       rpm-build
       rpm-sign
       rsync


### PR DESCRIPTION
This is required to build OpenSSL v3.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
