### PR TITLE
Additional fixes for EL9 and EL7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Install perl-FindBin & perl-lib on EL 9 and AmazonLinux (needed for OpenSSL v3)
+- Install devtoolset-11-toolchain on EL 7 (needed for newer git)
+
 ## 1.1.10 - *2023-12-08*
 
 - Ensure Perl IPC-Cmd is installed on EL based systems which is required for building OpenSSL v3

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,7 +17,9 @@ module CincOmnibus
             libffi-devel
             ncurses-devel
             openssh-clients
+            perl-FindBin
             perl-IPC-Cmd
+            perl-lib
             rpm-build
             rpm-sign
             rsync
@@ -45,7 +47,9 @@ module CincOmnibus
             wget
             zlib-devel
           )
+          pkgs << %w(centos-release-scl) if node['platform_version'].to_i == 7
           pkgs << %w(glibc-langpack-en glibc-locale-source) if node['platform_version'].to_i >= 8
+          pkgs << %w(perl-FindBin perl-lib) if node['platform_version'].to_i >= 9
           pkgs.append(omnibus_java_pkg)
           pkgs.flatten.sort
         when 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 package omnibus_packages if omnibus_packages
+package 'devtoolset-11-toolchain' if centos? && node['platform_version'].to_i == 7
 
 build_essential 'cinc-omnibus'
 

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -11,7 +11,9 @@ control 'default' do
       glibc-locale-source
       iproute
       openssh-clients
+      perl-FindBin
       perl-IPC-Cmd
+      perl-lib
       rsync
       tar
       tzdata
@@ -34,7 +36,9 @@ control 'default' do
       wget
       zlib-devel
     )
+    packages << %w(centos-release-scl devtoolset-11-toolchain) if os_version.to_i == 7
     packages << %w(glibc-langpack-en glibc-locale-source) if os_version.to_i >= 8
+    packages << %w(perl-FindBin perl-lib) if os_version.to_i >= 9
   when 'debian', 'ubuntu'
     packages = %w(
       automake


### PR DESCRIPTION
- Install perl-FindBin & perl-lib on EL 9 and AmazonLinux (needed for OpenSSL v3)
- Install devtoolset-11-toolchain on EL 7 (needed for newer git)

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
