### PR TITLE
Additional fixes that were missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Only install perl-FindBin perl-lib on newer AmazonLinux releases
+- Install devtoolset-10 instead of devtoolset-11 since the aarch64 install is broken
+
 ## 1.1.11 - *2023-12-08*
 
 - Install perl-FindBin & perl-lib on EL 9 and AmazonLinux (needed for OpenSSL v3)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,9 +17,7 @@ module CincOmnibus
             libffi-devel
             ncurses-devel
             openssh-clients
-            perl-FindBin
             perl-IPC-Cmd
-            perl-lib
             rpm-build
             rpm-sign
             rsync
@@ -28,6 +26,7 @@ module CincOmnibus
             wget
             zlib-devel
           )
+          pkgs << %w(perl-FindBin perl-lib) if node['platform_version'].to_i >= 2022
           pkgs.append(omnibus_java_pkg)
           pkgs.flatten.sort
         when 'rhel'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 package omnibus_packages if omnibus_packages
-package 'devtoolset-11-toolchain' if centos? && node['platform_version'].to_i == 7
+package 'devtoolset-10' if centos? && node['platform_version'].to_i == 7
 
 build_essential 'cinc-omnibus'
 

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -11,14 +11,13 @@ control 'default' do
       glibc-locale-source
       iproute
       openssh-clients
-      perl-FindBin
       perl-IPC-Cmd
-      perl-lib
       rsync
       tar
       tzdata
       wget
     )
+    packages << %w(perl-FindBin perl-lib) if os_version.to_i >= 2022
   when 'centos', 'redhat', 'almalinux'
     packages = %w(
       automake
@@ -36,7 +35,7 @@ control 'default' do
       wget
       zlib-devel
     )
-    packages << %w(centos-release-scl devtoolset-11-toolchain) if os_version.to_i == 7
+    packages << %w(centos-release-scl devtoolset-10) if os_version.to_i == 7
     packages << %w(glibc-langpack-en glibc-locale-source) if os_version.to_i >= 8
     packages << %w(perl-FindBin perl-lib) if os_version.to_i >= 9
   when 'debian', 'ubuntu'


### PR DESCRIPTION
- Only install perl-FindBin perl-lib on newer AmazonLinux releases
- Install devtoolset-10 instead of devtoolset-11 since the aarch64 install is broken

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
