### PR TITLE
Add missing perl-Digest-SHA and perl-bignum needed for newer OpenSSL builds on EL-based platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,12 @@ jobs:
           - almalinux-8
           - almalinux-9
           - amazonlinux-2023
-          - centos-stream-8
           - centos-stream-9
           - debian-11
           - debian-12
           - opensuse-leap-15
+          - rockylinux-8
+          - rockylinux-9
           - ubuntu-2004
           - ubuntu-2204
           - ubuntu-2404

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Add missing perl-Digest-SHA and perl-bignum needed for newer OpenSSL builds on EL-based platforms
+- Remove EOL CentOS Stream 8
+- Add Rocky Linux 8/9 to CI testing
+
 ## 1.1.16 - *2024-05-23*
 
 - Manually update to standardized files

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,7 +18,9 @@ module CincOmnibus
             libtool
             ncurses-devel
             openssh-clients
+            perl-Digest-SHA
             perl-IPC-Cmd
+            perl-bignum
             rpm-build
             rpm-sign
             rsync
@@ -39,7 +41,9 @@ module CincOmnibus
             libffi-devel
             libtool
             openssh-clients
+            perl-Digest-SHA
             perl-IPC-Cmd
+            perl-bignum
             rpm-build
             rpm-sign
             rsync

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -12,14 +12,16 @@ control 'default' do
       iproute
       libtool
       openssh-clients
+      perl-Digest-SHA
       perl-IPC-Cmd
+      perl-bignum
       rsync
       tar
       tzdata
       wget
     )
     packages << %w(perl-FindBin perl-lib) if os_version.to_i >= 2022
-  when 'centos', 'redhat', 'almalinux'
+  when 'centos', 'redhat', 'almalinux', 'rocky'
     packages = %w(
       automake
       bzip2
@@ -28,7 +30,9 @@ control 'default' do
       libffi-devel
       libtool
       openssh-clients
+      perl-Digest-SHA
       perl-IPC-Cmd
+      perl-bignum
       rpm-build
       rpm-sign
       rsync


### PR DESCRIPTION
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
