### PR TITLE
Remove pkg-config-lite from omnibus-toolchain binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## Unreleased
 
+- Remove pkg-config-lite from omnibus-toolchain binary path
+- Install pkgconf from distro as a replacement
+
 ## 1.2.1 - *2024-12-26*
 
 - Use cinc omnibus-toolchain for RHEL-10

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,6 +18,7 @@ module CincOmnibus
             libtool
             ncurses-devel
             openssh-clients
+            pkgconf
             perl-Digest-SHA
             perl-IPC-Cmd
             perl-bignum
@@ -41,6 +42,7 @@ module CincOmnibus
             libffi-devel
             libtool
             openssh-clients
+            pkgconf
             perl-Digest-SHA
             perl-IPC-Cmd
             perl-bignum
@@ -75,6 +77,7 @@ module CincOmnibus
             locales
             locales-all
             openssh-client
+            pkgconf
             rsync
             tar
             tzdata
@@ -97,6 +100,7 @@ module CincOmnibus
             libtool
             ncurses-devel
             openssh
+            pkgconf
             rpm-build
             rsync
             tar
@@ -150,6 +154,15 @@ module CincOmnibus
         when 'debian'
           %w(libpcre2-dev libselinux1-dev)
         end
+      end
+
+      def omnibus_pkgconfig_files
+        %w(
+          /opt/omnibus-toolchain/bin/pkg-config
+          /opt/omnibus-toolchain/embedded/bin/pkg-config
+          /opt/omnibus-toolchain/LICENSES/pkg-config-lite-COPYING
+          /opt/omnibus-toolchain/embedded/share/aclocal/pkg.m4
+        )
       end
 
       def omnibus_env

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,14 @@ chef_ingredient 'omnibus-toolchain' do
   action(windows? ? :install : :upgrade)
 end
 
+# TODO: Remove installed pkg-config-lite from omnibus-toolchain to prefer distro version
+omnibus_pkgconfig_files.each do |f|
+  file f do
+    manage_symlink_source true
+    action :delete
+  end
+end
+
 group 'omnibus' do
   append true
 end

--- a/test/integration/cinc-omnibus/controls/default.rb
+++ b/test/integration/cinc-omnibus/controls/default.rb
@@ -12,6 +12,7 @@ control 'default' do
       iproute
       libtool
       openssh-clients
+      pkgconf
       perl-Digest-SHA
       perl-IPC-Cmd
       perl-bignum
@@ -30,6 +31,7 @@ control 'default' do
       libffi-devel
       libtool
       openssh-clients
+      pkgconf
       perl-Digest-SHA
       perl-IPC-Cmd
       perl-bignum
@@ -62,6 +64,7 @@ control 'default' do
       locales
       locales-all
       openssh-client
+      pkgconf
       rsync
       tar
       tzdata
@@ -84,6 +87,7 @@ control 'default' do
       iproute2
       libtool
       openssh
+      pkgconf
       rpm-build
       rsync
       tar
@@ -113,6 +117,10 @@ control 'default' do
 
   describe package 'omnibus-toolchain' do
     it { should be_installed }
+  end
+
+  describe file '/opt/omnibus-toolchain/bin/pkg-config' do
+    it { should_not exist }
   end
 
   describe command '/opt/omnibus-toolchain/bin/ruby --version' do


### PR DESCRIPTION
Install pkgconf from distro as a replacement. This is due to issues trying to
install libnghttp2 not working with pkg-config-lite.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
