### PR TITLE
fix: add support for openSUSE Leap 16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - debian-13
           - fedora-latest
           - opensuse-leap-15
+          - opensuse-leap-16
           - oraclelinux-8
           - oraclelinux-9
           - rockylinux-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## [4.0.2](https://github.com/sous-chefs/cinc-omnibus/compare/v4.0.1...v4.0.2) (2026-06-15)
 
-
 ### Bug Fixes
 
 * use sous-chefs workflows 8.0.4 ([#70](https://github.com/sous-chefs/cinc-omnibus/issues/70)) ([a4f5189](https://github.com/sous-chefs/cinc-omnibus/commit/a4f5189d86ac48b1fcae297a6052a4668702a594))

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The toolchain package is sourced unconditionally from the Cinc Project's mirror 
 * Ubuntu 20.04+
 * Windows Server 2016+
 
-Current Kitchen verification covers AlmaLinux 8/9/10, Amazon Linux 2023, CentOS Stream 9/10, Debian 12/13, Fedora latest, openSUSE Leap 15, Oracle Linux 8/9, Rocky Linux 8/9/10, and Ubuntu 20.04/22.04/24.04/26.04. macOS, FreeBSD, and Windows are exercised via `kitchen.exec.yml` against real builder hosts.
+Current Kitchen verification covers AlmaLinux 8/9/10, Amazon Linux 2023, CentOS Stream 9/10, Debian 12/13, Fedora latest, openSUSE Leap 15/16, Oracle Linux 8/9, Rocky Linux 8/9/10, and Ubuntu 20.04/22.04/24.04/26.04. macOS, FreeBSD, and Windows are exercised via `kitchen.exec.yml` against real builder hosts.
 
 ## Resources
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -59,6 +59,11 @@ platforms:
       image: dokken/opensuse-leap-15
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: opensuse-leap-16
+    driver:
+      image: dokken/opensuse-leap-16.0
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: oraclelinux-8
     driver:
       image: dokken/oraclelinux-8

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -25,6 +25,7 @@ platforms:
   - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
+  - name: opensuse-leap-16
   - name: oraclelinux-8
   - name: oraclelinux-9
   - name: rockylinux-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,6 +32,7 @@ platforms:
   - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
+  - name: opensuse-leap-16
   - name: oraclelinux-8
   - name: oraclelinux-9
   - name: rockylinux-8

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -191,7 +191,8 @@ module CincOmnibus
             'openjdk-21-jdk-headless'
           end
         when 'opensuseleap'
-          'java-11-openjdk-devel'
+          # Leap 16.0 dropped the Java 11 packages; it ships OpenJDK 21.
+          node['platform_version'].to_i >= 16 ? 'java-21-openjdk-devel' : 'java-11-openjdk-devel'
         end
       end
 

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -67,6 +67,19 @@ describe 'cinc_omnibus_builder' do
         platform_version_compatibility_mode: true
       )
     end
+
+    it { is_expected.to install_package(%w(automake bzip2 curl git glibc-i18ndata glibc-locale gzip hostname iproute2 java-11-openjdk-devel libffi-devel libtool ncurses-devel openssh pkgconf rpm-build rsync tar timezone wget zlib-devel)) }
+  end
+
+  context 'on opensuse leap 16' do
+    platform 'opensuse', '16.0'
+
+    recipe do
+      cinc_omnibus_builder 'default'
+    end
+
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to install_package(%w(automake bzip2 curl git glibc-i18ndata glibc-locale gzip hostname iproute2 java-21-openjdk-devel libffi-devel libtool ncurses-devel openssh pkgconf rpm-build rsync tar timezone wget zlib-devel)) }
   end
 
   context 'on windows' do

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -132,7 +132,6 @@ control 'default' do
       gzip
       hostname
       iproute2
-      java-11-openjdk-devel
       libffi-devel
       libtool
       ncurses-devel
@@ -145,6 +144,12 @@ control 'default' do
       wget
       zlib-devel
     )
+    # Leap 16.0 dropped the Java 11 packages; it ships OpenJDK 21.
+    packages << if os_version.to_i >= 16
+                  %w(java-21-openjdk-devel)
+                else
+                  %w(java-11-openjdk-devel)
+                end
   when 'freebsd'
     packages = %w(
       autoconf


### PR DESCRIPTION
Leap 16.0 dropped the Java 11 packages (it ships OpenJDK 21), so the
build failed with "No candidate version available for
java-11-openjdk-devel". Version-gate the openSUSE Java package and add
Leap 16 to the test matrix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
