### PR TITLE
fix: allow zypper to downgrade runtime libs on openSUSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This file is used to list changes made in each version of the cinc-omnibus cookb
 
 ## [4.0.3](https://github.com/sous-chefs/cinc-omnibus/compare/v4.0.2...v4.0.3) (2026-06-19)
 
-
 ### Bug Fixes
 
 * add support for openSUSE Leap 16.0 ([#72](https://github.com/sous-chefs/cinc-omnibus/issues/72)) ([30f4c3c](https://github.com/sous-chefs/cinc-omnibus/commit/30f4c3cfed8fc40d990c322a153821738e4a803b))

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -209,6 +209,15 @@ action :create do
       # Work around a freebsd_pkgng multipackage bug (only the first name gets
       # a candidate version); install one at a time.
       new_resource.packages.each { |p| package p }
+    elsif platform_family?('suse')
+      # openSUSE Leap images can ship a runtime lib (e.g. libncurses6) that is
+      # newer than the matching *-devel package available in the configured
+      # repos, which makes a plain install of e.g. ncurses-devel unsatisfiable.
+      # Allow zypper to downgrade the runtime lib to the version the -devel
+      # package pins to so the dependency can be resolved.
+      package new_resource.packages do
+        options '--allow-downgrade'
+      end
     else
       package new_resource.packages
     end


### PR DESCRIPTION
openSUSE Leap images can ship a runtime lib (e.g. libncurses6) that is
newer than the matching *-devel package available in the configured
repos, which makes a plain install of e.g. ncurses-devel unsatisfiable
(the -devel package pins an exact, older libncurses6). Pass
--allow-downgrade on the suse package install so zypper can downgrade the
runtime lib to the version the -devel package requires.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
