### PR TITLE
feat: install and manage GitLab Runner on non-Linux builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # cinc-omnibus CHANGELOG
 
+<!-- markdownlint-disable-file MD012 -->
+<!-- release-please emits a double blank line after each version header. -->
+
 This file is used to list changes made in each version of the cinc-omnibus cookbook.
 
 ## [4.0.4](https://github.com/sous-chefs/cinc-omnibus/compare/v4.0.3...v4.0.4) (2026-06-20)

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -44,6 +44,20 @@ canonical autotools names resolve against Homebrew's renamed binaries: `libtooli
 `glibtoolize` always, and on Apple Silicon also `pkg-config` → Homebrew's `pkg-config` shim
 (which lives outside `/usr/local/bin` when Homebrew is in `/opt/homebrew`).
 
+## GitLab Runner
+
+On non-Linux builders (macOS, FreeBSD, Windows) the cookbook installs and manages the GitLab Runner
+via [`cinc_omnibus_gitlab_runner`](documentation/cinc_omnibus_gitlab_runner.md) (`manage_gitlab_runner`,
+default true). It never runs `gitlab-runner register` — registration stays manual. On Linux it is a
+no-op, since Linux omnibus builds run in Docker and the runner lives on the Docker host.
+
+On macOS the runner's omnibus `.dmg` step drives Finder via AppleScript, which needs the TCC
+*Automation* permission. Because Homebrew's `gitlab-runner` is ad-hoc signed and its identity changes
+on every version upgrade, that grant is normally lost on each `brew upgrade`. The cookbook re-signs
+the binary with a fixed self-signed identity so the grant persists; this still requires a **single**
+manual "Allow" click the first time (there is no MDM-free way to avoid that one prompt). See the
+resource docs for the one-time bootstrap and how to validate the AppleEvents client on your hosts.
+
 ## Source / Compiled Installation
 
 This cookbook prepares a build host; it does not compile Cinc or Omnibus projects itself.

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -82,3 +82,31 @@ $env:REPO_BRANCH = 'feat/cinc-toolchain-migration'
    user, and the load shim.
 5. Uninstalls Cinc Client and removes the scratch workspace. The build node no longer needs Cinc
    to run omnibus builds — those use `omnibus-toolchain`'s own Ruby.
+
+## macOS: build user and SecureToken
+
+On macOS the `user` resource that creates the build user (`omnibus` by default) runs through Chef's
+`mac_user` provider, which always manages the account's **SecureToken**. Chef demands
+`secure_token_password`, `admin_username`, and `admin_password` whenever it has to *change* the
+token (desired state ≠ current state):
+
+```text
+Chef::Exceptions::User: secure_token_password, admin_username and admin_password
+properties are required to modify SecureToken
+```
+
+A build user created from scratch by the bootstrap has no SecureToken, so historically this only
+bit when the user *already existed with one* — e.g. created by hand in System Settings, or granted a
+token by logging into the GUI (macOS auto-grants a token to the first interactive login on a Mac
+that has none).
+
+`cinc_omnibus_builder` handles this automatically: before creating the build user it reads the
+account's current SecureToken state (`sysadminctl -secureTokenStatus`) and declares that *same*
+state on the `user` resource. Because desired always matches current, `mac_user` never tries to
+toggle the token and never needs credentials — whether the user has a token or not, and even if the
+token gets auto-granted between runs. No configuration is required.
+
+SecureToken is a FileVault disk-encryption credential (and, on Apple Silicon, confers volume-owner
+status); it is **not** required for ordinary GUI login, screen sharing, SSH, or code signing, and
+with FileVault off it has no practical effect. The cookbook neither grants nor removes it — it only
+avoids fighting whatever state the account is already in.

--- a/documentation/cinc_omnibus_builder.md
+++ b/documentation/cinc_omnibus_builder.md
@@ -40,6 +40,10 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
 | `msys2_pinned_packages` | Array | `[]` | Exact `.pkg.tar.zst` files/URLs to `pacman -U`, passed to `cinc_omnibus_msys2`. |
 | `msys2_base_archive_date` | String | newest on the mirror | Dated MSYS2 base archive to install (defaults to the newest on the mirror), passed to `cinc_omnibus_msys2`. |
 | `msys2_verify_signature` | true, false | `true` | Verify the MSYS2 base archive's GPG signature, passed to `cinc_omnibus_msys2`. |
+| `manage_gitlab_runner` | true, false | `true` | Non-Linux only. Whether to install and manage the GitLab Runner via the [`cinc_omnibus_gitlab_runner`](cinc_omnibus_gitlab_runner.md) resource. No-op on Linux. |
+| `manage_gitlab_runner_service` | true, false | `true` | Whether the runner service is set up and started (passed to `cinc_omnibus_gitlab_runner`). |
+| `manage_gitlab_runner_signing` | true, false | `true` | macOS only. Whether to re-sign the runner binary with a fixed identity for a durable TCC grant (passed to `cinc_omnibus_gitlab_runner`). |
+| `gitlab_runner_version` | String, nil | `nil` | GitLab Runner version to install (passed to `cinc_omnibus_gitlab_runner`). |
 
 ## Platform notes
 
@@ -64,6 +68,13 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
   via pacman, and freezes gcc/binutils with `IgnorePkg` so upgrades are deliberate. The shim adds
   `C:\msys64\ucrt64\bin` and `C:\msys64\usr\bin` to PATH. Chocolatey is still used for the other
   Windows build tools (WiX, 7-Zip, the Windows SDK, Git).
+
+* **GitLab Runner (non-Linux only):** on macOS, FreeBSD, and Windows the builder also installs and
+  manages the GitLab Runner via the [`cinc_omnibus_gitlab_runner`](cinc_omnibus_gitlab_runner.md)
+  resource (unless `manage_gitlab_runner false`). Registration stays manual. On macOS it re-signs the
+  Homebrew binary with a fixed identity so the "control Finder" TCC grant survives upgrades — see that
+  resource's docs for the one-time bootstrap. On Linux this is a no-op (the runner lives on the Docker
+  host).
 
 ## Examples
 

--- a/documentation/cinc_omnibus_gitlab_runner.md
+++ b/documentation/cinc_omnibus_gitlab_runner.md
@@ -1,0 +1,118 @@
+# cinc_omnibus_gitlab_runner
+
+Installs the [GitLab Runner](https://docs.gitlab.com/runner/) on a **non-Linux** Cinc Omnibus build
+host (macOS, FreeBSD, Windows) and manages its service. On Linux it is a no-op — Linux omnibus
+builds run in Docker containers and the runner lives on the Docker host, not the build node.
+
+`cinc_omnibus_builder` invokes this resource automatically on non-Linux platforms (unless
+`manage_gitlab_runner false`); you normally don't declare it directly.
+
+> **Registration is never automated.** This resource installs the binary and the service but never
+> runs `gitlab-runner register` — connecting a runner to a GitLab instance with a registration token
+> stays a deliberate manual step. The service runs idle until a runner is registered.
+
+## Actions
+
+| Action | Description |
+| --- | --- |
+| `:create` | Installs/upgrades the `gitlab-runner` binary, manages the service, and (macOS) re-signs the binary for a durable TCC grant. Default action. |
+| `:remove` | Stops/removes the service and (macOS) the helper script. Package removal is opt-in with `remove_package true`. |
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `instance_name` | String | name property | Resource name. |
+| `version` | String, nil | `nil` (package default / latest) | Version to pass to the platform package provider. Best-effort on Homebrew (which tracks the latest formula). |
+| `manage_service` | true, false | `true` | Whether to set up and start the runner service (macOS LaunchAgent, FreeBSD rc.d, Windows service). |
+| `build_user` | String | `'omnibus'` | macOS only: the user whose GUI session the LaunchAgent runs in, and who owns the signing keychain. |
+| `build_user_home` | String | platform-specific | Home of `build_user`. |
+| `manage_macos_signing` | true, false | `true` | macOS only: re-sign the binary with a fixed self-signed identity so the Automation/TCC grant survives upgrades (see below). |
+| `signing_identity` | String | `'Cinc Omnibus GitLab Runner Code Signing'` | macOS only: common name of the self-signed code-signing certificate. |
+| `signing_identifier` | String | `'sh.cinc.omnibus.gitlab-runner'` | macOS only: `codesign --identifier` used when re-signing. |
+| `signing_keychain` | String | `<home>/Library/Keychains/cinc-omnibus-signing.keychain-db` | macOS only: dedicated keychain holding the signing identity. |
+| `signing_keychain_password` | String | `'cinc-omnibus'` | macOS only: password for the signing keychain. Self-signed, locally-trusted only; override per site. |
+| `windows_install_dir` | String | `C:\GitLab-Runner` | Windows only: working directory / config location for the service. |
+| `remove_package` | true, false | `false` | Whether `:remove` should also uninstall the `gitlab-runner` package. |
+
+## Platform notes
+
+### macOS
+
+* **Install:** `gitlab-runner` via Homebrew (matching the cookbook's existing Homebrew-managed
+  macOS handling). `build_user` should own the Homebrew prefix, so that the install, the
+  re-signing, and the per-user LaunchAgent all run as the same account.
+* **Service:** started with `brew services start gitlab-runner` **as `build_user`, without sudo**,
+  so it is a per-user **LaunchAgent** in the build user's GUI (Aqua) session. This is the only mode
+  GitLab supports on macOS, and it is required anyway — the omnibus `.dmg` packaging step drives
+  Finder via AppleScript, which only works from a GUI session. It is restarted automatically after
+  an upgrade. Because the agent loads into the build user's `gui/<uid>` launchd domain, the cookbook
+  only (re)starts it when `build_user` owns the console — enable **auto-login** for `build_user` so
+  it's logged in across reboots and converges. On a host with no one logged in, the start step is
+  skipped (rather than failing the run) and the agent loads at next login.
+* **The TCC "control Finder" problem and the fix.** That Finder AppleScript needs the macOS TCC
+  **Automation** permission (`gitlab-runner` → Finder). Homebrew ships `gitlab-runner` as a Go
+  binary that is ad-hoc signed at build time, so its code-signing identity (cdhash) changes on every
+  *version upgrade* — which invalidates the prior TCC grant and forces a manual "Allow" click in the
+  GUI after each `brew upgrade gitlab-runner`.
+
+  With `manage_macos_signing true` (default), the resource creates a fixed self-signed code-signing
+  identity once (in a dedicated keychain owned by `build_user`) and **re-signs the binary with that
+  stable identity after every upgrade**. Because the designated requirement then stays constant, a
+  one-time Automation grant persists across all future upgrades.
+
+  **One-time bootstrap (do this once, ever):** after the first converge re-signs the binary, log in
+  to the build host's console as `build_user`, run the helper the cookbook drops at
+  `~/finder-auth-flow.scpt`, and click **Allow** on the "gitlab-runner wants to control Finder"
+  prompt:
+
+  ```sh
+  osascript ~/finder-auth-flow.scpt
+  ```
+
+  After that, `brew upgrade gitlab-runner` needs no manual intervention.
+
+  > **The grant persists only as long as the signing keychain survives.** It lives in a dedicated
+  > keychain owned by `build_user`. If that keychain or identity is lost (re-image, build-user
+  > recreation, home wipe), the next converge mints a *new* certificate with a different designated
+  > requirement, so the grant is lost and you re-run the one-time `finder-auth-flow.scpt` bootstrap
+  > once more. To keep the grant stable across host rebuilds, pre-provision the same identity (import
+  > a fixed `.p12`) instead of letting each host generate its own.
+  >
+  > **Validate the client identity on your hosts first.** macOS attributes the AppleEvent to the
+  > *responsible* process; confirm it is `gitlab-runner` (not `/usr/bin/osascript`) by triggering a
+  > build and checking the prompt, or:
+  > `log show --last 1h --predicate 'subsystem == "com.apple.TCC"' | grep -i appleevents`.
+  > If a different binary is named, set `signing_identifier`/`signing_identity` to target it. There
+  > is no MDM-free way around the **single** initial Allow click; this approach removes the
+  > *per-upgrade* clicks. (With MDM, prefer an `AppleEvents` PPPC profile instead and set
+  > `manage_macos_signing false`.)
+
+### FreeBSD
+
+* **Install:** the community port/package `gitlab-runner` (`devel/gitlab-runner`), which also brings
+  the rc.d service, the `gitlab-runner` user/group, and runtime deps (bash, git, ca_root_nss). There
+  is no GitLab-official FreeBSD package, and **no upstream `freebsd-arm64` binary** — rely on the
+  port (built for the host arch) on arm64 hosts.
+* **Service:** enabled and started via rc.d (`gitlab_runner`).
+
+### Windows
+
+* **Install:** `chocolatey_package 'gitlab-runner'` (matching the cookbook's existing chocolatey
+  usage). The package drops the binary and a PATH shim without creating a service by default.
+* **Service:** installed with `gitlab-runner install` under the **Built-in System Account**
+  (headless, no password) pointed at `windows_install_dir`, then enabled and started. A Windows
+  service is non-interactive (no GUI), which is correct for headless omnibus builds.
+
+## Examples
+
+```ruby
+# Managed automatically by cinc_omnibus_builder; equivalent to:
+cinc_omnibus_gitlab_runner 'default'
+
+# Install the binary but leave the service and TCC handling alone:
+cinc_omnibus_gitlab_runner 'default' do
+  manage_service false
+  manage_macos_signing false
+end
+```

--- a/files/default/finder-auth-flow.scpt
+++ b/files/default/finder-auth-flow.scpt
@@ -1,0 +1,12 @@
+-- Forces the macOS TCC "Automation" prompt that lets gitlab-runner control
+-- Finder (omnibus drives Finder when styling the .dmg window). Run this ONCE,
+-- at the console, as the build user, after the cookbook first re-signs the
+-- gitlab-runner binary with the stable signing identity, then click "Allow".
+-- Because the binary is re-signed with that same identity on every upgrade,
+-- the grant then persists across `brew upgrade gitlab-runner` and the prompt
+-- does not reappear.
+tell application "Finder"
+	reopen
+	activate
+	set selection to {}
+end tell

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -394,6 +394,31 @@ module CincOmnibus
           '/var/cache/omnibus'
         end
       end
+
+      # macOS only. True when the build user already holds a SecureToken. We
+      # mirror this onto the user resource so Chef's mac_user provider sees no
+      # divergence and never tries to toggle the token (which would demand
+      # admin credentials we don't have). sysadminctl writes status to stderr;
+      # if it isn't available we assume no token.
+      def mac_build_user_secure_token?(user)
+        return false unless mac_os_x?
+
+        status = shell_out('sysadminctl', '-secureTokenStatus', user)
+        "#{status.stdout}#{status.stderr}".match?(/Secure token is ENABLED/)
+      rescue Errno::ENOENT
+        false
+      end
+
+      # Homebrew's prefix: /opt/homebrew on Apple Silicon, /usr/local on Intel.
+      def mac_brew_prefix
+        arm? ? '/opt/homebrew' : '/usr/local'
+      end
+
+      # The gitlab-runner binary installed by Homebrew (a symlink into the
+      # Cellar; codesign follows it to sign the real Mach-O).
+      def gitlab_runner_mac_binary(prefix = mac_brew_prefix)
+        ::File.join(prefix, 'bin', 'gitlab-runner')
+      end
     end
   end
 end

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -30,6 +30,10 @@ property :msys2_ignore_packages, Array, default: lazy { msys2_default_ignore_pac
 property :msys2_pinned_packages, Array, default: []
 property :msys2_base_archive_date, String, default: lazy { msys2_latest_base_archive_date }
 property :msys2_verify_signature, [true, false], default: true
+property :manage_gitlab_runner, [true, false], default: true
+property :manage_gitlab_runner_service, [true, false], default: true
+property :manage_gitlab_runner_signing, [true, false], default: true
+property :gitlab_runner_version, [String, nil]
 
 default_action :create
 
@@ -264,10 +268,16 @@ action :create do
       append true
     end
 
+    # Declare the build user's existing SecureToken state (macOS only) so the
+    # mac_user provider doesn't try to toggle it, which would need admin creds.
+    # Computed here, not in the block: sub-resource blocks can't see our helpers.
+    build_user_secure_token = mac_build_user_secure_token?(new_resource.build_user)
+
     user new_resource.build_user do
       home new_resource.build_user_home
       group new_resource.build_group
       shell new_resource.build_user_shell
+      secure_token build_user_secure_token if mac_os_x?
     end
   end
 
@@ -368,6 +378,18 @@ action :create do
       end
     end
   end
+
+  # Install the GitLab Runner on non-Linux builders (Linux runners live on the
+  # Docker host). Registration stays manual; this never runs `register`.
+  if new_resource.manage_gitlab_runner && !linux?
+    cinc_omnibus_gitlab_runner new_resource.instance_name do
+      build_user new_resource.build_user
+      build_user_home new_resource.build_user_home
+      version new_resource.gitlab_runner_version
+      manage_service new_resource.manage_gitlab_runner_service
+      manage_macos_signing new_resource.manage_gitlab_runner_signing
+    end
+  end
 end
 
 action :remove do
@@ -408,6 +430,16 @@ action :remove do
 
   if windows? && new_resource.manage_msys2 && new_resource.remove_packages
     cinc_omnibus_msys2 new_resource.instance_name do
+      action :remove
+    end
+  end
+
+  if new_resource.manage_gitlab_runner && !linux?
+    cinc_omnibus_gitlab_runner new_resource.instance_name do
+      build_user new_resource.build_user
+      build_user_home new_resource.build_user_home
+      manage_service new_resource.manage_gitlab_runner_service
+      remove_package new_resource.remove_packages
       action :remove
     end
   end

--- a/resources/gitlab_runner.rb
+++ b/resources/gitlab_runner.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+
+provides :cinc_omnibus_gitlab_runner
+unified_mode true
+
+include CincOmnibus::Cookbook::Helpers
+
+property :instance_name, String, name_property: true
+property :version, [String, nil]
+property :manage_service, [true, false], default: true
+property :build_user, String, default: 'omnibus'
+property :build_user_home, String, default: lazy { default_build_user_home }
+
+# macOS code-signing: re-sign the Homebrew binary with a fixed self-signed
+# identity so its TCC "Automation" (control Finder) grant survives upgrades.
+property :manage_macos_signing, [true, false], default: true
+property :signing_identity, String, default: 'Cinc Omnibus GitLab Runner Code Signing'
+property :signing_identifier, String, default: 'sh.cinc.omnibus.gitlab-runner'
+property :signing_keychain, String,
+         default: lazy { ::File.join(build_user_home, 'Library', 'Keychains', 'cinc-omnibus-signing.keychain-db') }
+property :signing_keychain_password, String, default: 'cinc-omnibus', sensitive: true
+
+property :windows_install_dir, String,
+         default: lazy { windows_safe_path_join(windows_system_drive, 'GitLab-Runner') }
+
+property :remove_package, [true, false], default: false
+
+default_action :create
+
+action_class do
+  include CincOmnibus::Cookbook::Helpers
+end
+
+# Registration (`gitlab-runner register`) is intentionally never performed here;
+# it stays a manual step. The service runs idle until a runner is registered.
+action :create do
+  # On Linux the runner lives on the Docker host, not the build node.
+  next if linux?
+
+  if mac_os_x?
+    package 'gitlab-runner' do
+      version new_resource.version if new_resource.version
+    end
+
+    if new_resource.manage_macos_signing
+      binary = gitlab_runner_mac_binary
+      keychain = new_resource.signing_keychain
+      password = new_resource.signing_keychain_password
+      identity = new_resource.signing_identity
+      identifier = new_resource.signing_identifier
+      home = new_resource.build_user_home
+      build_user = new_resource.build_user
+      build_env = { 'HOME' => home }
+
+      directory ::File.dirname(keychain) do
+        owner build_user
+        recursive true
+      end
+
+      # Create the dedicated signing keychain + a stable self-signed
+      # code-signing identity. Idempotent: skipped once the identity exists.
+      bash 'create gitlab-runner signing identity' do
+        user build_user
+        environment build_env
+        sensitive true
+        code <<~BASH
+          set -e
+          KEYCHAIN=#{Shellwords.escape(keychain)}
+          KCPASS=#{Shellwords.escape(password)}
+          IDENTITY=#{Shellwords.escape(identity)}
+          [ -f "$KEYCHAIN" ] || security create-keychain -p "$KCPASS" "$KEYCHAIN"
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
+          TMP=$(mktemp -d)
+          trap 'rm -rf "$TMP"' EXIT
+          # Use a config file (not -addext) so the codeSigning EKU is set on every
+          # macOS LibreSSL version.
+          {
+            echo '[req]'
+            echo 'distinguished_name = dn'
+            echo 'x509_extensions = v3'
+            echo '[dn]'
+            echo '[v3]'
+            echo 'basicConstraints = critical,CA:FALSE'
+            echo 'keyUsage = critical,digitalSignature'
+            echo 'extendedKeyUsage = critical,codeSigning'
+          } > "$TMP/req.cnf"
+          openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+            -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+            -subj "/CN=$IDENTITY" -config "$TMP/req.cnf"
+          openssl pkcs12 -export -out "$TMP/id.p12" \
+            -inkey "$TMP/key.pem" -in "$TMP/cert.pem" -passout pass:"$KCPASS"
+          # codesign is pointed at this keychain explicitly (--keychain), so it
+          # need not be added to the user search list.
+          security import "$TMP/id.p12" -k "$KEYCHAIN" -P "$KCPASS" -T /usr/bin/codesign -A
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
+        BASH
+        not_if "security find-identity -v -p codesigning #{Shellwords.escape(keychain)} | grep -Fq #{Shellwords.escape(identity)}",
+               user: build_user, environment: build_env
+      end
+
+      # Re-sign with the stable identity. Idempotent via the signature check, so
+      # it re-runs after every `brew upgrade` (which replaces the binary).
+      # Do NOT add --options runtime: the binary must stay non-hardened so it can
+      # send AppleEvents to Finder without the apple-events entitlement.
+      esc_binary = Shellwords.escape(binary)
+      execute 'resign gitlab-runner' do
+        command [
+          "security unlock-keychain -p #{Shellwords.escape(password)} #{Shellwords.escape(keychain)}",
+          "codesign --force --sign #{Shellwords.escape(identity)} --identifier #{Shellwords.escape(identifier)} " \
+          "--keychain #{Shellwords.escape(keychain)} #{esc_binary}",
+          "codesign --verify --strict #{esc_binary}",
+        ].join(' && ')
+        user build_user
+        environment build_env
+        sensitive true
+        not_if "codesign -d --verbose=4 #{esc_binary} 2>&1 | grep -Fq #{Shellwords.escape("Authority=#{identity}")} && " \
+               "codesign -d --verbose=4 #{esc_binary} 2>&1 | grep -Fq #{Shellwords.escape("Identifier=#{identifier}")}",
+               user: build_user, environment: build_env
+        notifies :run, 'execute[restart gitlab-runner service]', :immediately if new_resource.manage_service
+      end
+
+      # One-time TCC grant helper (replaces the standalone finder-auth-flow repo).
+      cookbook_file ::File.join(home, 'finder-auth-flow.scpt') do
+        source 'finder-auth-flow.scpt'
+        cookbook 'cinc-omnibus'
+        owner build_user
+        mode '0755'
+      end
+    end
+
+    if new_resource.manage_service
+      service_user = new_resource.build_user
+      service_env = { 'HOME' => new_resource.build_user_home }
+      # The LaunchAgent loads into gui/<uid>, so brew services only works when
+      # build_user owns the console (is logged in). Skip cleanly otherwise — a
+      # headless converge (e.g. CI) would error trying to bootstrap into a
+      # nonexistent Aqua session.
+      console_owned = %([ "$(stat -f %u /dev/console)" = "$(id -u #{Shellwords.escape(service_user)})" ])
+
+      # macOS supports only a per-user LaunchAgent (in the GUI session) — never
+      # sudo/LaunchDaemon. brew services without sudo writes the user agent.
+      execute 'enable gitlab-runner service' do
+        command 'brew services start gitlab-runner'
+        user service_user
+        environment service_env
+        only_if console_owned, user: service_user, environment: service_env
+        not_if 'brew services list | grep -E "^gitlab-runner[[:space:]]+started"',
+               user: service_user, environment: service_env
+      end
+
+      execute 'restart gitlab-runner service' do
+        command 'brew services restart gitlab-runner'
+        user service_user
+        environment service_env
+        action :nothing
+        only_if console_owned, user: service_user, environment: service_env
+        # When signing is on, the resign step is the restart trigger. Only fall
+        # back to the package subscription when signing is disabled, so the
+        # service still restarts on an upgrade in that mode.
+        subscribes :run, 'package[gitlab-runner]', :immediately unless new_resource.manage_macos_signing
+      end
+    end
+  elsif freebsd?
+    # Bootstrap the pkg catalog so the install finds a candidate (pkgng never
+    # fetches on its own). Idempotent via creates; a no-op when invoked from
+    # cinc_omnibus_builder, which already does this.
+    execute 'pkg update' do
+      command 'pkg update'
+      creates '/var/db/pkg/repos/FreeBSD/db'
+    end
+
+    # The community port (devel/gitlab-runner) brings the rc.d service, the
+    # gitlab-runner user/group, and runtime deps (bash, git, ca_root_nss).
+    package 'gitlab-runner' do
+      version new_resource.version if new_resource.version
+    end
+
+    service 'gitlab_runner' do
+      action [:enable, :start]
+    end if new_resource.manage_service
+  elsif windows?
+    chocolatey_package 'gitlab-runner' do
+      version new_resource.version if new_resource.version
+    end
+
+    if new_resource.manage_service
+      install_dir = new_resource.windows_install_dir
+
+      directory install_dir
+
+      # Built-in System Account service (headless, no password). Guarded so an
+      # already-installed service isn't reinstalled. Refresh PATH from the
+      # registry first: chocolatey adds the runner's dir to the machine PATH
+      # during this same converge, which the running process won't see yet.
+      powershell_script 'install gitlab-runner service' do
+        code <<~PS1
+          $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
+          gitlab-runner install --working-directory "#{install_dir}" --config "#{windows_safe_path_join(install_dir, 'config.toml')}"
+        PS1
+        not_if 'Get-Service -Name gitlab-runner -ErrorAction SilentlyContinue'
+      end
+
+      service 'gitlab-runner' do
+        action [:enable, :start]
+      end
+    end
+  end
+end
+
+action :remove do
+  next if linux?
+
+  if mac_os_x?
+    if new_resource.manage_service
+      service_user = new_resource.build_user
+      service_env = { 'HOME' => new_resource.build_user_home }
+
+      execute 'stop gitlab-runner service' do
+        command 'brew services stop gitlab-runner'
+        user service_user
+        environment service_env
+        only_if 'brew services list | grep -E "^gitlab-runner[[:space:]]+(started|scheduled)"',
+                user: service_user, environment: service_env
+      end
+    end
+
+    # Reverse the signing keychain :create created (delete-keychain also drops
+    # it from the search list).
+    execute 'delete gitlab-runner signing keychain' do
+      command "security delete-keychain #{Shellwords.escape(new_resource.signing_keychain)}"
+      user new_resource.build_user
+      environment('HOME' => new_resource.build_user_home)
+      only_if { ::File.exist?(new_resource.signing_keychain) }
+    end
+
+    file ::File.join(new_resource.build_user_home, 'finder-auth-flow.scpt') do
+      action :delete
+    end
+
+    package 'gitlab-runner' do
+      action :remove
+    end if new_resource.remove_package
+  elsif freebsd?
+    service 'gitlab_runner' do
+      action [:stop, :disable]
+    end if new_resource.manage_service
+
+    package 'gitlab-runner' do
+      action :remove
+    end if new_resource.remove_package
+  elsif windows?
+    if new_resource.manage_service
+      powershell_script 'uninstall gitlab-runner service' do
+        code <<~PS1
+          $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
+          gitlab-runner stop; gitlab-runner uninstall
+        PS1
+        only_if 'Get-Service -Name gitlab-runner -ErrorAction SilentlyContinue'
+      end
+    end
+
+    chocolatey_package 'gitlab-runner' do
+      action :remove
+    end if new_resource.remove_package
+  end
+end

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -23,4 +23,53 @@ RSpec.describe CincOmnibus::Cookbook::Helpers do
       expect(helper.to_msys_path('/tmp/cache')).to eq('/tmp/cache')
     end
   end
+
+  describe '#mac_build_user_secure_token?' do
+    before { allow(helper).to receive(:mac_os_x?).and_return(true) }
+
+    def sysadminctl(stderr)
+      instance_double(Mixlib::ShellOut, stdout: '', stderr: stderr)
+        .tap { |s| allow(helper).to receive(:shell_out).and_return(s) }
+    end
+
+    it 'is true when sysadminctl reports the token ENABLED' do
+      sysadminctl('Secure token is ENABLED for user omnibus')
+      expect(helper.mac_build_user_secure_token?('omnibus')).to be true
+    end
+
+    it 'is false when sysadminctl reports the token DISABLED' do
+      sysadminctl('Secure token is DISABLED for user omnibus')
+      expect(helper.mac_build_user_secure_token?('omnibus')).to be false
+    end
+
+    it 'is false when sysadminctl is unavailable' do
+      allow(helper).to receive(:shell_out).and_raise(Errno::ENOENT)
+      expect(helper.mac_build_user_secure_token?('omnibus')).to be false
+    end
+
+    it 'is false off macOS and does not shell out' do
+      allow(helper).to receive(:mac_os_x?).and_return(false)
+      expect(helper).not_to receive(:shell_out)
+      expect(helper.mac_build_user_secure_token?('omnibus')).to be false
+    end
+  end
+
+  describe '#mac_brew_prefix' do
+    it 'is /opt/homebrew on Apple Silicon' do
+      allow(helper).to receive(:arm?).and_return(true)
+      expect(helper.mac_brew_prefix).to eq('/opt/homebrew')
+    end
+
+    it 'is /usr/local on Intel' do
+      allow(helper).to receive(:arm?).and_return(false)
+      expect(helper.mac_brew_prefix).to eq('/usr/local')
+    end
+  end
+
+  describe '#gitlab_runner_mac_binary' do
+    it 'resolves under the Homebrew prefix' do
+      allow(helper).to receive(:arm?).and_return(true)
+      expect(helper.gitlab_runner_mac_binary).to eq('/opt/homebrew/bin/gitlab-runner')
+    end
+  end
 end

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -28,6 +28,8 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to create_file('/home/omnibus/.gitconfig') }
     it { is_expected.to create_file('/home/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
+    # The runner lives on the Docker host on Linux, not the build node.
+    it { is_expected.to_not create_cinc_omnibus_gitlab_runner('default') }
   end
 
   context 'ubuntu - ppc64le' do
@@ -108,6 +110,7 @@ describe 'cinc_omnibus_builder' do
     # MSYS2 is managed by cinc_omnibus_msys2 (needs pacman), not choco.
     it { is_expected.to_not install_chocolatey_package('msys2') }
     it { is_expected.to install_cinc_omnibus_msys2('default') }
+    it { is_expected.to create_cinc_omnibus_gitlab_runner('default') }
 
     # File::ALT_SEPARATOR is nil on Linux (the chefspec host) so
     # windows_safe_path_join leaves forward slashes in place.
@@ -132,6 +135,10 @@ describe 'cinc_omnibus_builder' do
     platform 'mac_os_x', '12'
     automatic_attributes['kernel']['machine'] = 'x86_64'
 
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(false)
+    end
+
     recipe do
       cinc_omnibus_builder 'default'
     end
@@ -142,10 +149,33 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to_not create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
     it { is_expected.to create_link('/usr/local/bin/libtoolize').with(to: '/usr/local/bin/glibtoolize') }
     it { is_expected.to_not create_link('/usr/local/bin/pkg-config') }
+    # No SecureToken detected on the build user -> declared false, no toggle.
+    it { is_expected.to create_user('omnibus').with(secure_token: false) }
+    it { is_expected.to create_cinc_omnibus_gitlab_runner('default') }
+  end
+
+  context 'on macos when the build user already has a SecureToken' do
+    platform 'mac_os_x', '12'
+
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(true)
+    end
+
+    recipe do
+      cinc_omnibus_builder 'default'
+    end
+
+    # Existing token is mirrored, so mac_user sees no divergence and converges.
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to create_user('omnibus').with(secure_token: true) }
   end
 
   context 'on macos arm64' do
     platform 'mac_os_x', '12'
+
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(false)
+    end
 
     recipe do
       cinc_omnibus_builder 'default'
@@ -168,6 +198,7 @@ describe 'cinc_omnibus_builder' do
     end
     it { is_expected.to create_file('/home/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to_not create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
+    it { is_expected.to create_cinc_omnibus_gitlab_runner('default') }
   end
 
   context 'debian - ppc64le' do

--- a/spec/unit/resources/gitlab_runner_spec.rb
+++ b/spec/unit/resources/gitlab_runner_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'cinc_omnibus_gitlab_runner' do
+  step_into :cinc_omnibus_gitlab_runner
+
+  recipe do
+    cinc_omnibus_gitlab_runner 'default'
+  end
+
+  context 'on macos arm64' do
+    platform 'mac_os_x', '12'
+
+    before do
+      stub_command(/security find-identity/).and_return(false)
+      stub_command(/codesign -d/).and_return(false)
+      stub_command(/brew services list/).and_return(false)
+      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+    end
+
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to install_package('gitlab-runner') }
+
+    it 'creates the stable signing identity' do
+      is_expected.to run_bash('create gitlab-runner signing identity')
+    end
+
+    it 're-signs the Apple Silicon binary with the fixed identity' do
+      is_expected.to run_execute('resign gitlab-runner').with(
+        command: %r{/opt/homebrew/bin/gitlab-runner}
+      )
+    end
+
+    it 'signs with the configured identifier' do
+      is_expected.to run_execute('resign gitlab-runner').with(
+        command: /--identifier sh\.cinc\.omnibus\.gitlab-runner/
+      )
+    end
+
+    it { is_expected.to create_cookbook_file('/Users/omnibus/finder-auth-flow.scpt') }
+
+    it 'starts the LaunchAgent as the build user without sudo' do
+      is_expected.to run_execute('enable gitlab-runner service').with(
+        command: 'brew services start gitlab-runner',
+        user: 'omnibus'
+      )
+    end
+  end
+
+  context 'on macos intel' do
+    platform 'mac_os_x', '12'
+    automatic_attributes['kernel']['machine'] = 'x86_64'
+
+    before do
+      stub_command(/security find-identity/).and_return(false)
+      stub_command(/codesign -d/).and_return(false)
+      stub_command(/brew services list/).and_return(false)
+      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+    end
+
+    it 're-signs the Intel binary path' do
+      is_expected.to run_execute('resign gitlab-runner').with(
+        command: %r{/usr/local/bin/gitlab-runner}
+      )
+    end
+  end
+
+  context 'on macos with signing disabled' do
+    platform 'mac_os_x', '12'
+
+    before do
+      stub_command(/brew services list/).and_return(false)
+      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+    end
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        manage_macos_signing false
+      end
+    end
+
+    it { is_expected.to install_package('gitlab-runner') }
+    it { is_expected.to_not run_execute('resign gitlab-runner') }
+    it { is_expected.to_not create_cookbook_file('/Users/omnibus/finder-auth-flow.scpt') }
+    it { is_expected.to run_execute('enable gitlab-runner service') }
+  end
+
+  context 'on freebsd' do
+    platform 'freebsd', '12.1'
+
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to install_package('gitlab-runner') }
+    it { is_expected.to enable_service('gitlab_runner') }
+    it { is_expected.to start_service('gitlab_runner') }
+    # No macOS signing/AppleScript on FreeBSD.
+    it { is_expected.to_not run_execute('resign gitlab-runner') }
+  end
+
+  context 'on windows' do
+    platform 'windows'
+
+    before { stub_command(/Get-Service/).and_return(false) }
+
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to install_chocolatey_package('gitlab-runner') }
+    it { is_expected.to run_powershell_script('install gitlab-runner service') }
+    it { is_expected.to enable_service('gitlab-runner') }
+    it { is_expected.to start_service('gitlab-runner') }
+  end
+
+  context 'on linux (no-op: runner lives on the Docker host)' do
+    platform 'ubuntu', '24.04'
+
+    it { expect { chef_run }.to_not raise_error }
+    it { is_expected.to_not install_package('gitlab-runner') }
+    it { is_expected.to_not run_execute('resign gitlab-runner') }
+  end
+
+  context 'with remove action on freebsd' do
+    platform 'freebsd', '12.1'
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        action :remove
+      end
+    end
+
+    it { is_expected.to disable_service('gitlab_runner') }
+    it { is_expected.to stop_service('gitlab_runner') }
+    # Package removal is opt-in.
+    it { is_expected.to_not remove_package('gitlab-runner') }
+  end
+end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
-cinc_omnibus_builder 'default'
+cinc_omnibus_builder 'default' do
+  # The GitLab Runner needs a GUI login (macOS LaunchAgent) and brew/keychain
+  # ownership that the headless exec-kitchen runners don't have; it's covered by
+  # the unit specs instead. Host-prep verification doesn't need it.
+  manage_gitlab_runner false
+end


### PR DESCRIPTION
Add a cinc_omnibus_gitlab_runner resource that installs the GitLab Runner on
macOS, FreeBSD, and Windows build hosts and manages its service, wired into
cinc_omnibus_builder via manage_gitlab_runner (default true; no-op on Linux,
where the runner lives on the Docker host). Registration is never automated.

On macOS the Homebrew binary is re-signed with a fixed self-signed identity so
its TCC "control Finder" Automation grant survives `brew upgrade`, eliminating
the per-upgrade manual approval (subsumes the finder-auth-flow helper, now
shipped as a cookbook file). The build user's existing SecureToken state is also
mirrored onto the user resource so the mac_user provider never tries to toggle
it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
