### PR TITLE
fix: make the macOS gitlab-runner code-signing path work headlessly

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'shellwords'
+
 module CincOmnibus
   module Cookbook
     module Helpers
@@ -418,6 +420,123 @@ module CincOmnibus
       # Cellar; codesign follows it to sign the real Mach-O).
       def gitlab_runner_mac_binary(prefix = mac_brew_prefix)
         ::File.join(prefix, 'bin', 'gitlab-runner')
+      end
+
+      # The gitlab_runner_* helpers below back the cinc_omnibus_gitlab_runner
+      # provider's guards and scripts; they reference new_resource and shell out,
+      # so they are only valid in action context.
+
+      def gitlab_runner_build_env
+        { 'HOME' => new_resource.build_user_home }
+      end
+
+      def gitlab_runner_run_as_build_user(command)
+        shell_out(command, user: new_resource.build_user, environment: gitlab_runner_build_env)
+      end
+
+      # bash that (re)creates the dedicated signing keychain and a single stable
+      # self-signed code-signing identity.
+      def gitlab_runner_signing_keychain_script
+        <<~BASH
+          set -e
+          KEYCHAIN=#{Shellwords.escape(new_resource.signing_keychain)}
+          KCPASS=#{Shellwords.escape(new_resource.signing_keychain_password)}
+          IDENTITY=#{Shellwords.escape(new_resource.signing_identity)}
+          # Recreate from scratch so we never accumulate duplicate identities
+          # (codesign --sign by name is ambiguous when more than one matches).
+          security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+          security create-keychain -p "$KCPASS" "$KEYCHAIN"
+          # Unlock BEFORE set-keychain-settings: on a locked keychain the latter
+          # needs an interactive unlock, which fails ("User interaction is not
+          # allowed") in a headless/non-GUI converge. With the password supplied
+          # up front, none of the commands below need an interactive session.
+          security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
+          security set-keychain-settings "$KEYCHAIN"
+          TMP=$(mktemp -d)
+          trap 'rm -rf "$TMP"' EXIT
+          # Use a config file (not -addext) so the codeSigning EKU is set on every
+          # macOS LibreSSL version.
+          {
+            echo '[req]'
+            echo 'distinguished_name = dn'
+            echo 'x509_extensions = v3'
+            echo '[dn]'
+            echo '[v3]'
+            echo 'basicConstraints = critical,CA:FALSE'
+            echo 'keyUsage = critical,digitalSignature'
+            echo 'extendedKeyUsage = critical,codeSigning'
+          } > "$TMP/req.cnf"
+          # Use the system LibreSSL (/usr/bin/openssl), not whatever is on PATH:
+          # a Homebrew openssl@3 exports PKCS#12 with a SHA-256 MAC that macOS
+          # `security import` rejects ("MAC verification failed"). LibreSSL
+          # defaults to the SHA1-MAC/3DES form `security` reads natively.
+          /usr/bin/openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes -keyout "$TMP/key.pem" -out "$TMP/cert.pem" -subj "/CN=$IDENTITY" -config "$TMP/req.cnf"
+          /usr/bin/openssl pkcs12 -export -out "$TMP/id.p12" -inkey "$TMP/key.pem" -in "$TMP/cert.pem" -passout pass:"$KCPASS"
+          security import "$TMP/id.p12" -k "$KEYCHAIN" -P "$KCPASS" -T /usr/bin/codesign -A
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
+        BASH
+      end
+
+      # The resign command: unlock the keychain, re-sign with the stable identity,
+      # and verify. Kept non-hardened (no --options runtime) so the binary can
+      # send AppleEvents to Finder without the apple-events entitlement.
+      def gitlab_runner_resign_command
+        keychain = Shellwords.escape(new_resource.signing_keychain)
+        binary = Shellwords.escape(gitlab_runner_mac_binary)
+        [
+          "security unlock-keychain -p #{Shellwords.escape(new_resource.signing_keychain_password)} #{keychain}",
+          "codesign --force --sign #{Shellwords.escape(new_resource.signing_identity)} " \
+          "--identifier #{Shellwords.escape(new_resource.signing_identifier)} --keychain #{keychain} #{binary}",
+          "codesign --verify --strict #{binary}",
+        ].join(' && ')
+      end
+
+      # True when EXACTLY ONE matching identity exists: 0 = not set up yet, 2+ =
+      # duplicates that make codesign --sign ambiguous. No -v, since a self-signed
+      # cert is untrusted and never shows under "valid identities only".
+      def gitlab_runner_signing_identity_ready?
+        count = "security find-identity -p codesigning #{Shellwords.escape(new_resource.signing_keychain)} " \
+                "2>/dev/null | grep -Fc #{Shellwords.escape(new_resource.signing_identity)}"
+        gitlab_runner_run_as_build_user(%([ "$(#{count})" -eq 1 ])).exitstatus.zero?
+      end
+
+      def gitlab_runner_keychain_in_search_list?
+        gitlab_runner_run_as_build_user(
+          "security list-keychains -d user | grep -Fq #{Shellwords.escape(new_resource.signing_keychain)}"
+        ).exitstatus.zero?
+      end
+
+      # True when the binary already carries our stable identity (Authority CN and
+      # Identifier both match), so the resign is a no-op until the next upgrade
+      # replaces the binary.
+      def gitlab_runner_binary_signed?
+        binary = Shellwords.escape(gitlab_runner_mac_binary)
+        gitlab_runner_run_as_build_user(
+          "codesign -d --verbose=4 #{binary} 2>&1 | grep -Fq #{Shellwords.escape("Authority=#{new_resource.signing_identity}")} && " \
+          "codesign -d --verbose=4 #{binary} 2>&1 | grep -Fq #{Shellwords.escape("Identifier=#{new_resource.signing_identifier}")}"
+        ).exitstatus.zero?
+      end
+
+      def gitlab_runner_service_started?
+        gitlab_runner_run_as_build_user('brew services list | grep -E "^gitlab-runner[[:space:]]+started"').exitstatus.zero?
+      end
+
+      def gitlab_runner_service_active?
+        gitlab_runner_run_as_build_user('brew services list | grep -E "^gitlab-runner[[:space:]]+(started|scheduled)"').exitstatus.zero?
+      end
+
+      # The LaunchAgent loads into gui/<uid>, so brew services only works when
+      # build_user owns the console (is logged in); otherwise skip cleanly.
+      def gitlab_runner_console_owned_by_build_user?
+        gitlab_runner_run_as_build_user(%([ "$(stat -f %u /dev/console)" = "$(id -u #{Shellwords.escape(new_resource.build_user)})" ])).exitstatus.zero?
+      end
+
+      def gitlab_runner_signing_keychain_exists?
+        ::File.exist?(new_resource.signing_keychain)
+      end
+
+      def gitlab_runner_windows_service_installed?
+        !powershell_out('Get-Service -Name gitlab-runner -ErrorAction SilentlyContinue').stdout.strip.empty?
       end
     end
   end

--- a/resources/gitlab_runner.rb
+++ b/resources/gitlab_runner.rb
@@ -40,90 +40,58 @@ action :create do
   next if linux?
 
   if mac_os_x?
+    build_user = new_resource.build_user
+    build_env = gitlab_runner_build_env
+
     package 'gitlab-runner' do
       version new_resource.version if new_resource.version
     end
 
     if new_resource.manage_macos_signing
-      binary = gitlab_runner_mac_binary
       keychain = new_resource.signing_keychain
-      password = new_resource.signing_keychain_password
-      identity = new_resource.signing_identity
-      identifier = new_resource.signing_identifier
-      home = new_resource.build_user_home
-      build_user = new_resource.build_user
-      build_env = { 'HOME' => home }
+      signing_script = gitlab_runner_signing_keychain_script
+      resign_command = gitlab_runner_resign_command
 
       directory ::File.dirname(keychain) do
         owner build_user
         recursive true
       end
 
-      # Create the dedicated signing keychain + a stable self-signed
-      # code-signing identity. Idempotent: skipped once the identity exists.
+      # Create the dedicated signing keychain + a single stable self-signed
+      # code-signing identity. Self-heals 0/2+ identity states (see helper).
       bash 'create gitlab-runner signing identity' do
         user build_user
         environment build_env
         sensitive true
-        code <<~BASH
-          set -e
-          KEYCHAIN=#{Shellwords.escape(keychain)}
-          KCPASS=#{Shellwords.escape(password)}
-          IDENTITY=#{Shellwords.escape(identity)}
-          [ -f "$KEYCHAIN" ] || security create-keychain -p "$KCPASS" "$KEYCHAIN"
-          security set-keychain-settings "$KEYCHAIN"
-          security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
-          TMP=$(mktemp -d)
-          trap 'rm -rf "$TMP"' EXIT
-          # Use a config file (not -addext) so the codeSigning EKU is set on every
-          # macOS LibreSSL version.
-          {
-            echo '[req]'
-            echo 'distinguished_name = dn'
-            echo 'x509_extensions = v3'
-            echo '[dn]'
-            echo '[v3]'
-            echo 'basicConstraints = critical,CA:FALSE'
-            echo 'keyUsage = critical,digitalSignature'
-            echo 'extendedKeyUsage = critical,codeSigning'
-          } > "$TMP/req.cnf"
-          openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
-            -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
-            -subj "/CN=$IDENTITY" -config "$TMP/req.cnf"
-          openssl pkcs12 -export -out "$TMP/id.p12" \
-            -inkey "$TMP/key.pem" -in "$TMP/cert.pem" -passout pass:"$KCPASS"
-          # codesign is pointed at this keychain explicitly (--keychain), so it
-          # need not be added to the user search list.
-          security import "$TMP/id.p12" -k "$KEYCHAIN" -P "$KCPASS" -T /usr/bin/codesign -A
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
-        BASH
-        not_if "security find-identity -v -p codesigning #{Shellwords.escape(keychain)} | grep -Fq #{Shellwords.escape(identity)}",
-               user: build_user, environment: build_env
+        code signing_script
+        not_if { gitlab_runner_signing_identity_ready? }
       end
 
-      # Re-sign with the stable identity. Idempotent via the signature check, so
-      # it re-runs after every `brew upgrade` (which replaces the binary).
-      # Do NOT add --options runtime: the binary must stay non-hardened so it can
-      # send AppleEvents to Finder without the apple-events entitlement.
-      esc_binary = Shellwords.escape(binary)
+      # codesign discovers the identity through the user keychain search list
+      # (the --keychain flag alone is unreliable). Separate + idempotent so it
+      # also repairs hosts whose identity already exists. build_user's home has
+      # no spaces, so the unquoted rebuild of the existing list is safe.
+      execute 'add gitlab-runner signing keychain to search list' do
+        command "security list-keychains -d user -s #{Shellwords.escape(keychain)} " \
+                "$(security list-keychains -d user | tr -d '\"')"
+        user build_user
+        environment build_env
+        not_if { gitlab_runner_keychain_in_search_list? }
+      end
+
+      # Re-sign with the stable identity; idempotent, so it re-runs after every
+      # `brew upgrade` (which replaces the binary).
       execute 'resign gitlab-runner' do
-        command [
-          "security unlock-keychain -p #{Shellwords.escape(password)} #{Shellwords.escape(keychain)}",
-          "codesign --force --sign #{Shellwords.escape(identity)} --identifier #{Shellwords.escape(identifier)} " \
-          "--keychain #{Shellwords.escape(keychain)} #{esc_binary}",
-          "codesign --verify --strict #{esc_binary}",
-        ].join(' && ')
+        command resign_command
         user build_user
         environment build_env
         sensitive true
-        not_if "codesign -d --verbose=4 #{esc_binary} 2>&1 | grep -Fq #{Shellwords.escape("Authority=#{identity}")} && " \
-               "codesign -d --verbose=4 #{esc_binary} 2>&1 | grep -Fq #{Shellwords.escape("Identifier=#{identifier}")}",
-               user: build_user, environment: build_env
+        not_if { gitlab_runner_binary_signed? }
         notifies :run, 'execute[restart gitlab-runner service]', :immediately if new_resource.manage_service
       end
 
       # One-time TCC grant helper (replaces the standalone finder-auth-flow repo).
-      cookbook_file ::File.join(home, 'finder-auth-flow.scpt') do
+      cookbook_file ::File.join(new_resource.build_user_home, 'finder-auth-flow.scpt') do
         source 'finder-auth-flow.scpt'
         cookbook 'cinc-omnibus'
         owner build_user
@@ -132,32 +100,25 @@ action :create do
     end
 
     if new_resource.manage_service
-      service_user = new_resource.build_user
-      service_env = { 'HOME' => new_resource.build_user_home }
-      # The LaunchAgent loads into gui/<uid>, so brew services only works when
-      # build_user owns the console (is logged in). Skip cleanly otherwise — a
-      # headless converge (e.g. CI) would error trying to bootstrap into a
-      # nonexistent Aqua session.
-      console_owned = %([ "$(stat -f %u /dev/console)" = "$(id -u #{Shellwords.escape(service_user)})" ])
-
       # macOS supports only a per-user LaunchAgent (in the GUI session) — never
-      # sudo/LaunchDaemon. brew services without sudo writes the user agent.
+      # sudo/LaunchDaemon. brew services without sudo writes the user agent, and
+      # the agent only loads when build_user owns the console, so a headless
+      # converge skips cleanly instead of failing to bootstrap a gui/<uid> domain.
       execute 'enable gitlab-runner service' do
         command 'brew services start gitlab-runner'
-        user service_user
-        environment service_env
-        only_if console_owned, user: service_user, environment: service_env
-        not_if 'brew services list | grep -E "^gitlab-runner[[:space:]]+started"',
-               user: service_user, environment: service_env
+        user build_user
+        environment build_env
+        only_if { gitlab_runner_console_owned_by_build_user? }
+        not_if { gitlab_runner_service_started? }
       end
 
       execute 'restart gitlab-runner service' do
         command 'brew services restart gitlab-runner'
-        user service_user
-        environment service_env
+        user build_user
+        environment build_env
         action :nothing
-        only_if console_owned, user: service_user, environment: service_env
-        # When signing is on, the resign step is the restart trigger. Only fall
+        only_if { gitlab_runner_console_owned_by_build_user? }
+        # When signing is on, the resign step is the restart trigger; only fall
         # back to the package subscription when signing is disabled, so the
         # service still restarts on an upgrade in that mode.
         subscribes :run, 'package[gitlab-runner]', :immediately unless new_resource.manage_macos_signing
@@ -200,7 +161,7 @@ action :create do
           $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
           gitlab-runner install --working-directory "#{install_dir}" --config "#{windows_safe_path_join(install_dir, 'config.toml')}"
         PS1
-        not_if 'Get-Service -Name gitlab-runner -ErrorAction SilentlyContinue'
+        not_if { gitlab_runner_windows_service_installed? }
       end
 
       service 'gitlab-runner' do
@@ -214,16 +175,15 @@ action :remove do
   next if linux?
 
   if mac_os_x?
-    if new_resource.manage_service
-      service_user = new_resource.build_user
-      service_env = { 'HOME' => new_resource.build_user_home }
+    build_user = new_resource.build_user
+    build_env = gitlab_runner_build_env
 
+    if new_resource.manage_service
       execute 'stop gitlab-runner service' do
         command 'brew services stop gitlab-runner'
-        user service_user
-        environment service_env
-        only_if 'brew services list | grep -E "^gitlab-runner[[:space:]]+(started|scheduled)"',
-                user: service_user, environment: service_env
+        user build_user
+        environment build_env
+        only_if { gitlab_runner_service_active? }
       end
     end
 
@@ -231,9 +191,9 @@ action :remove do
     # it from the search list).
     execute 'delete gitlab-runner signing keychain' do
       command "security delete-keychain #{Shellwords.escape(new_resource.signing_keychain)}"
-      user new_resource.build_user
-      environment('HOME' => new_resource.build_user_home)
-      only_if { ::File.exist?(new_resource.signing_keychain) }
+      user build_user
+      environment build_env
+      only_if { gitlab_runner_signing_keychain_exists? }
     end
 
     file ::File.join(new_resource.build_user_home, 'finder-auth-flow.scpt') do
@@ -258,7 +218,7 @@ action :remove do
           $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
           gitlab-runner stop; gitlab-runner uninstall
         PS1
-        only_if 'Get-Service -Name gitlab-runner -ErrorAction SilentlyContinue'
+        only_if { gitlab_runner_windows_service_installed? }
       end
     end
 

--- a/spec/unit/resources/gitlab_runner_spec.rb
+++ b/spec/unit/resources/gitlab_runner_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 describe 'cinc_omnibus_gitlab_runner' do
   step_into :cinc_omnibus_gitlab_runner
 
+  # The guards are block form calling Helpers predicates (which shell out at
+  # converge time); stub them like msys2_spec does for its guards.
+  def stub_guard(name, value)
+    allow_any_instance_of(CincOmnibus::Cookbook::Helpers).to receive(name).and_return(value)
+  end
+
   recipe do
     cinc_omnibus_gitlab_runner 'default'
   end
@@ -13,10 +19,11 @@ describe 'cinc_omnibus_gitlab_runner' do
     platform 'mac_os_x', '12'
 
     before do
-      stub_command(/security find-identity/).and_return(false)
-      stub_command(/codesign -d/).and_return(false)
-      stub_command(/brew services list/).and_return(false)
-      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+      stub_guard(:gitlab_runner_signing_identity_ready?, false)
+      stub_guard(:gitlab_runner_keychain_in_search_list?, false)
+      stub_guard(:gitlab_runner_binary_signed?, false)
+      stub_guard(:gitlab_runner_service_started?, false)
+      stub_guard(:gitlab_runner_console_owned_by_build_user?, true)
     end
 
     it { expect { chef_run }.to_not raise_error }
@@ -24,6 +31,10 @@ describe 'cinc_omnibus_gitlab_runner' do
 
     it 'creates the stable signing identity' do
       is_expected.to run_bash('create gitlab-runner signing identity')
+    end
+
+    it 'adds the signing keychain to the search list so codesign can find it' do
+      is_expected.to run_execute('add gitlab-runner signing keychain to search list')
     end
 
     it 're-signs the Apple Silicon binary with the fixed identity' do
@@ -53,10 +64,11 @@ describe 'cinc_omnibus_gitlab_runner' do
     automatic_attributes['kernel']['machine'] = 'x86_64'
 
     before do
-      stub_command(/security find-identity/).and_return(false)
-      stub_command(/codesign -d/).and_return(false)
-      stub_command(/brew services list/).and_return(false)
-      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+      stub_guard(:gitlab_runner_signing_identity_ready?, false)
+      stub_guard(:gitlab_runner_keychain_in_search_list?, false)
+      stub_guard(:gitlab_runner_binary_signed?, false)
+      stub_guard(:gitlab_runner_service_started?, false)
+      stub_guard(:gitlab_runner_console_owned_by_build_user?, true)
     end
 
     it 're-signs the Intel binary path' do
@@ -70,8 +82,8 @@ describe 'cinc_omnibus_gitlab_runner' do
     platform 'mac_os_x', '12'
 
     before do
-      stub_command(/brew services list/).and_return(false)
-      stub_command(%r{stat -f %u /dev/console}).and_return(true)
+      stub_guard(:gitlab_runner_service_started?, false)
+      stub_guard(:gitlab_runner_console_owned_by_build_user?, true)
     end
 
     recipe do
@@ -100,7 +112,7 @@ describe 'cinc_omnibus_gitlab_runner' do
   context 'on windows' do
     platform 'windows'
 
-    before { stub_command(/Get-Service/).and_return(false) }
+    before { stub_guard(:gitlab_runner_windows_service_installed?, false) }
 
     it { expect { chef_run }.to_not raise_error }
     it { is_expected.to install_chocolatey_package('gitlab-runner') }
@@ -115,6 +127,26 @@ describe 'cinc_omnibus_gitlab_runner' do
     it { expect { chef_run }.to_not raise_error }
     it { is_expected.to_not install_package('gitlab-runner') }
     it { is_expected.to_not run_execute('resign gitlab-runner') }
+  end
+
+  context 'with remove action on macos' do
+    platform 'mac_os_x', '12'
+
+    before do
+      stub_guard(:gitlab_runner_service_active?, true)
+      stub_guard(:gitlab_runner_signing_keychain_exists?, true)
+    end
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        action :remove
+      end
+    end
+
+    it { is_expected.to run_execute('stop gitlab-runner service') }
+    it { is_expected.to run_execute('delete gitlab-runner signing keychain') }
+    it { is_expected.to delete_file('/Users/omnibus/finder-auth-flow.scpt') }
+    it { is_expected.to_not remove_package('gitlab-runner') }
   end
 
   context 'with remove action on freebsd' do


### PR DESCRIPTION
The macOS re-signing introduced in 4.1.0 failed during a headless converge.
Fix the whole keychain/codesign flow:

- Unlock the signing keychain before set-keychain-settings — on a locked
  keychain the latter triggers an interactive unlock that fails with "User
  interaction is not allowed" off a GUI session.
- Generate the PKCS#12 with the system LibreSSL (/usr/bin/openssl): a Homebrew
  openssl@3 on PATH writes a SHA-256 MAC that macOS `security import` rejects.
- Add the signing keychain to the user search list so codesign can find the
  identity; the --keychain flag alone is unreliable.
- Recreate the keychain from scratch and gate setup on exactly one matching
  identity, so duplicate certs (which made codesign --sign ambiguous) self-heal.

Also extract the guards, the signing-keychain script, and the resign command
into Helpers predicates/methods (mirroring cinc_omnibus_msys2).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
