### PR TITLE
fix: keep the macOS build user SSH-reachable and default tar to GNU tar

### DIFF
--- a/documentation/cinc_omnibus_builder.md
+++ b/documentation/cinc_omnibus_builder.md
@@ -52,9 +52,12 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
   `/usr/local/share/ruby-docker-copy-patch.rb`, and on Debian ARM versions older than 12 creates
   `/usr/bin/mkdir` and `/bin/install` compatibility symlinks.
 * **macOS:** installs Homebrew prerequisites, installs the `omnibus-toolchain` `.pkg`, and creates
-  `/usr/local/bin/libtoolize` → Homebrew's `glibtoolize`. On Apple Silicon also creates
+  `/usr/local/bin/libtoolize` → Homebrew's `glibtoolize` and `/usr/local/bin/tar` → Homebrew's
+  `gtar` (the system `tar` is bsdtar, which rejects GNU options). On Apple Silicon also creates
   `/usr/local/bin/pkg-config` → Homebrew's `pkg-config`, since the Homebrew prefix
-  (`/opt/homebrew`) isn't on the default omnibus PATH.
+  (`/opt/homebrew`) isn't on the default omnibus PATH. Because the build user's primary group is
+  set to `omnibus`, it also keeps the user in the `com.apple.access_ssh` group so SSH logins keep
+  working when Remote Login is limited to specific users.
 * **FreeBSD:** installs `pkg` prerequisites and the `omnibus-toolchain` self-extracting `.sh`.
 * **Windows:** installs chocolatey and the build tools it manages (WiX, 7-Zip, the Windows SDK,
   Git), installs the `omnibus-toolchain` `.msi` to `C:\cinc-project\omnibus-toolchain`, skips the

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -126,6 +126,7 @@ module CincOmnibus
             autoconf
             automake
             git
+            gnu-tar
             libffi
             libtool
             libyaml
@@ -460,6 +461,26 @@ module CincOmnibus
         "#{status.stdout}#{status.stderr}".match?(/Secure token is ENABLED/)
       rescue Errno::ENOENT
         false
+      end
+
+      # macOS Remote Login limited to specific users gates on membership in the
+      # com.apple.access_ssh Service ACL; the build user's primary-group change
+      # can drop it, so the builder re-adds the user.
+      def mac_ssh_access_grant_command(user)
+        "dseditgroup -o edit -a #{Shellwords.escape(user)} -t user com.apple.access_ssh"
+      end
+
+      # True when the build user is already in that SSH access group.
+      def mac_ssh_access_granted?(user)
+        shell_out('dseditgroup', '-o', 'checkmember', '-m', user, 'com.apple.access_ssh').exitstatus.zero?
+      end
+
+      # True when Remote Login is limited to specific users: the SACL group
+      # exists only in that mode (it's renamed *-disabled for "all users"), so
+      # its presence is the signal to manage membership — and the guard that
+      # keeps us from flipping an all-users host into restricted mode.
+      def mac_ssh_access_restricted?
+        shell_out('dseditgroup', '-o', 'read', 'com.apple.access_ssh').exitstatus.zero?
       end
 
       # Homebrew's prefix: /opt/homebrew on Apple Silicon, /usr/local on Intel.

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -222,18 +222,35 @@ action :create do
   end
 
   if mac_os_x?
-    # Homebrew names libtool's binary glibtoolize, and on Apple Silicon puts
-    # pkg-config outside the default omnibus PATH.
+    # Homebrew names libtool's binary glibtoolize and ships GNU tar as gtar (the
+    # system bsdtar rejects GNU options like --warning=no-file-changed); on Apple
+    # Silicon it also puts pkg-config outside the default omnibus PATH.
     brew_prefix = arm? ? '/opt/homebrew' : '/usr/local'
 
     link '/usr/local/bin/libtoolize' do
       to ::File.join(brew_prefix, 'bin', 'glibtoolize')
     end
 
+    # /usr/local/bin precedes /usr/bin in the default macOS PATH, so this makes
+    # GNU tar the global `tar`.
+    link '/usr/local/bin/tar' do
+      to ::File.join(brew_prefix, 'bin', 'gtar')
+    end
+
     if arm?
       link '/usr/local/bin/pkg-config' do
         to ::File.join(brew_prefix, 'bin', 'pkg-config')
       end
+    end
+
+    # Setting the build user's primary group to `omnibus` can drop it from the
+    # com.apple.access_ssh SACL, locking it out where Remote Login is limited to
+    # specific users. Re-add it — but only when that SACL exists, so we never
+    # flip an all-users host into restricted mode. Idempotent via checkmember.
+    execute 'grant build user ssh access' do
+      command mac_ssh_access_grant_command(new_resource.build_user)
+      only_if { mac_ssh_access_restricted? }
+      not_if  { mac_ssh_access_granted?(new_resource.build_user) }
     end
   end
 

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -9,6 +9,12 @@ describe 'cinc_omnibus_builder' do
   before do
     allow_any_instance_of(Chef::HTTP::Simple).to receive(:get)
       .and_return('msys2-base-x86_64-20260611.sfx.exe')
+    # macOS build-user SSH-access grant guards (unused off macOS): SACL present
+    # (restricted Remote Login) and the build user not yet a member.
+    allow_any_instance_of(CincOmnibus::Cookbook::Helpers)
+      .to receive(:mac_ssh_access_restricted?).and_return(true)
+    allow_any_instance_of(CincOmnibus::Cookbook::Helpers)
+      .to receive(:mac_ssh_access_granted?).and_return(false)
   end
 
   context 'on ubuntu' do
@@ -144,11 +150,13 @@ describe 'cinc_omnibus_builder' do
     end
 
     it { expect { chef_run }.to_not raise_error }
-    it { is_expected.to install_package(%w(autoconf automake git libffi libtool libyaml openssl@3 pkgconf readline)) }
+    it { is_expected.to install_package(%w(autoconf automake git gnu-tar libffi libtool libyaml openssl@3 pkgconf readline)) }
     it { is_expected.to create_template('/Users/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to_not create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
     it { is_expected.to create_link('/usr/local/bin/libtoolize').with(to: '/usr/local/bin/glibtoolize') }
+    it { is_expected.to create_link('/usr/local/bin/tar').with(to: '/usr/local/bin/gtar') }
     it { is_expected.to_not create_link('/usr/local/bin/pkg-config') }
+    it { is_expected.to run_execute('grant build user ssh access').with(command: 'dseditgroup -o edit -a omnibus -t user com.apple.access_ssh') }
     # No SecureToken detected on the build user -> declared false, no toggle.
     it { is_expected.to create_user('omnibus').with(secure_token: false) }
     it { is_expected.to create_cinc_omnibus_gitlab_runner('default') }
@@ -182,7 +190,9 @@ describe 'cinc_omnibus_builder' do
     end
 
     it { is_expected.to create_link('/usr/local/bin/libtoolize').with(to: '/opt/homebrew/bin/glibtoolize') }
+    it { is_expected.to create_link('/usr/local/bin/tar').with(to: '/opt/homebrew/bin/gtar') }
     it { is_expected.to create_link('/usr/local/bin/pkg-config').with(to: '/opt/homebrew/bin/pkg-config') }
+    it { is_expected.to run_execute('grant build user ssh access') }
   end
 
   context 'on freebsd' do

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -165,6 +165,7 @@ control 'default' do
       autoconf
       automake
       git
+      gnu-tar
       libffi
       libtool
       libyaml
@@ -287,6 +288,22 @@ control 'default' do
     tool_cmds.each do |cmd|
       describe command "PATH='#{install_dir}/bin:/usr/local/bin:#{unix_path}' #{cmd}" do
         its('exit_status') { should eq 0 }
+      end
+    end
+
+    # macOS system tar is bsdtar; the builder links /usr/local/bin/tar -> gtar,
+    # so the global `tar` must resolve to GNU tar.
+    if os.darwin?
+      describe command "PATH='/usr/local/bin:#{unix_path}' tar --version" do
+        its('stdout') { should match(/GNU tar/) }
+      end
+
+      # Where Remote Login is limited to specific users (the SACL group exists),
+      # the builder keeps the build user in it so operators can log in.
+      if command('dseditgroup -o read com.apple.access_ssh').exit_status.zero?
+        describe command 'dseditgroup -o checkmember -m omnibus com.apple.access_ssh' do
+          its('exit_status') { should eq 0 }
+        end
       end
     end
   end


### PR DESCRIPTION
* Re-add the build user to the `com.apple.access_ssh` SACL: setting its
  primary group to `omnibus` drops it when Remote Login is limited to
  specific users, so sshd closes the session right after auth.
* Install `gnu-tar` and link `/usr/local/bin/tar` -> `gtar`: the system
  bsdtar rejects GNU options like `--warning=no-file-changed`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
