### PR TITLE
fix: full-upgrade MSYS2 before installing build deps

### DIFF
--- a/documentation/cinc_omnibus_msys2.md
+++ b/documentation/cinc_omnibus_msys2.md
@@ -49,6 +49,20 @@ dedicated keyring and runs `gpg --verify` on the downloaded archive via `remote_
 property, which fails the converge on a bad signature. `gpg` comes from Git for Windows, installed
 by `cinc_omnibus_builder`. Set `verify_signature false` to skip (not recommended).
 
+## Updates and partial-upgrade safety
+
+MSYS2 is a rolling release that only supports full system upgrades. Installing a single package
+against a stale database (`pacman -Sy <pkg>`) is a *partial upgrade*: a freshly fetched package
+links against a library soname (e.g. `msys-nettle-9.dll`) that the older, un-upgraded dependency
+no longer provides, producing `cannot open shared object file` errors at runtime. To avoid this,
+provisioning runs a full `pacman -Syuu` to bring the whole system to the mirror's current state
+*before* installing the build deps, so everything links against matching libraries.
+
+Because upgrading `msys2-runtime` swaps `msys-2.0.dll` out from under the running shell, the upgrade
+runs in up to two passes, reaping any process still holding the old runtime in between. The upgrade
+and install are guarded by the `etc/.cinc-packages-installed` sentinel, so they run once per builder;
+remove the sentinel and re-converge to pull updates.
+
 ## How gcc is controlled
 
 The MSYS2 base archive contains only the MSYS2 runtime — **never gcc**. The ucrt64 compiler is

--- a/resources/msys2.rb
+++ b/resources/msys2.rb
@@ -77,19 +77,45 @@ action :install do
     creates initialized
   end
 
-  # Optional pin/rollback: install exact .pkg.tar.zst files (paths or URLs).
-  unless new_resource.pinned_packages.empty?
-    execute 'install pinned msys2 packages' do
-      command msys2_shell("pacman -U --needed --noconfirm #{new_resource.pinned_packages.join(' ')}")
+  installed = windows_safe_path_join(new_resource.install_dir, 'etc', '.cinc-packages-installed')
+
+  # Full `-Syuu` first: rolling-release MSYS2 only supports full upgrades, and
+  # `pacman -Sy <pkg>` partial-upgrades, linking new packages (wget) against
+  # sonames the old deps (nettle) no longer ship. Per MSYS2 CI guidance run it
+  # twice (core then the rest), reaping leftover runtime processes between.
+  # Redirect output so a keyring hook's dirmngr/gpg-agent can't hold Chef's pipe
+  # and hang (see the gpg reaper below); clear a stale db.lck from a killed pass.
+  # Guarded (with everything below) by the install sentinel, so it runs once.
+  upgrade_log = '/tmp/cinc-msys2-upgrade.log'
+  2.times do |pass|
+    execute "upgrade msys2 base (pass #{pass + 1})" do
+      command msys2_shell(%(rm -f /var/lib/pacman/db.lck; pacman -Syuu --noconfirm --overwrite "*" > #{upgrade_log} 2>&1))
+      timeout 900
+      ignore_failure true # a runtime swap can kill or hang this pass
+      not_if { ::File.exist?(installed) }
+    end
+
+    execute "reap msys2 runtime processes (pass #{pass + 1})" do
+      command 'taskkill /F /FI "MODULES eq msys-2.0.dll"'
+      returns [0, 128] # 128 = nothing matched
+      not_if { ::File.exist?(installed) }
     end
   end
 
-  # Refresh db and install; avoid full `pacman -Syu` (hangs on a runtime
-  # restart). Success-only sentinel keeps it idempotent (group queries are
-  # unreliable as a guard).
-  installed = windows_safe_path_join(new_resource.install_dir, 'etc', '.cinc-packages-installed')
+  # Optional pin/rollback: install exact .pkg.tar.zst files (paths or URLs)
+  # before the live install so the freeze below keeps them in place.
+  unless new_resource.pinned_packages.empty?
+    execute 'install pinned msys2 packages' do
+      command msys2_shell("pacman -U --needed --noconfirm #{new_resource.pinned_packages.join(' ')}")
+      not_if { ::File.exist?(installed) }
+    end
+  end
+
+  # Install the build deps from the db the upgrade just synced (no -y: reuse the
+  # consistent snapshot). Success-only sentinel keeps it idempotent (group
+  # queries are unreliable as a guard).
   execute 'install msys2 packages' do
-    command msys2_shell("pacman -Sy --needed --noconfirm #{new_resource.packages.join(' ')} && touch /etc/.cinc-packages-installed")
+    command msys2_shell("pacman -S --needed --noconfirm #{new_resource.packages.join(' ')} && touch /etc/.cinc-packages-installed")
     creates installed
   end
 

--- a/spec/unit/resources/msys2_spec.rb
+++ b/spec/unit/resources/msys2_spec.rb
@@ -53,9 +53,21 @@ describe 'cinc_omnibus_msys2' do
       expect(chef_run.ruby_block('set msys2 IgnorePkg')).to_not be_nil
     end
 
-    it 'refreshes and installs the ucrt64 toolchain' do
+    it 'fully upgrades the system before installing (no partial upgrades)' do
+      expect(chef_run).to run_execute('upgrade msys2 base (pass 1)')
+        .with(command: /pacman -Syuu --noconfirm/)
+      expect(chef_run).to run_execute('upgrade msys2 base (pass 2)')
+        .with(command: /pacman -Syuu --noconfirm/)
+    end
+
+    it 'reaps processes holding the old runtime between upgrade passes' do
+      expect(chef_run).to run_execute('reap msys2 runtime processes (pass 1)')
+        .with(command: /taskkill .*MODULES eq msys-2\.0\.dll/, returns: [0, 128])
+    end
+
+    it 'installs the ucrt64 toolchain from the upgraded db' do
       expect(chef_run).to run_execute('install msys2 packages')
-        .with(command: /pacman -Sy --needed --noconfirm .*mingw-w64-ucrt-x86_64-toolchain/)
+        .with(command: /pacman -S --needed --noconfirm .*mingw-w64-ucrt-x86_64-toolchain/)
     end
 
     it { is_expected.to_not run_execute('install pinned msys2 packages') }


### PR DESCRIPTION
`pacman -Sy <pkg>` partial-upgrades, linking new packages (wget) against
sonames the old deps (nettle) no longer ship -- "cannot open shared object
file: msys-nettle-9.dll".

- run a full `pacman -Syuu` before `pacman -S`, twice per MSYS2 CI guidance
- reap leftover msys-2.0.dll processes between passes
- redirect upgrade output so a keyring hook can't hang the converge on Chef's pipe
- clear a stale db.lck so a killed pass can't wedge the next one

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
