### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -96,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -8,13 +8,10 @@ provisioner:
   enforce_idempotency: true
   deprecations_as_errors: true
   chef_license: accept-no-persist
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
-
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
 
 x-verifiers:
   default: &default_verifier
@@ -56,5 +53,6 @@ platforms:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier


### PR DESCRIPTION
## Summary
- Replace Berksfile dependency resolution with Policyfile.rb
- Update ChefSpec and Kitchen to use Policyfile resolution
- Update Copilot setup for chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- markdownlint-cli2 "**/*.md"
- embedded rspec --format progress
- git diff --check
- kitchen list