### PR TITLE
fix(msys2): Enforce ucrt64-only toolchain and rebase after provisioning

### DIFF
--- a/documentation/cinc_omnibus_msys2.md
+++ b/documentation/cinc_omnibus_msys2.md
@@ -63,6 +63,33 @@ runs in up to two passes, reaping any process still holding the old runtime in b
 and install are guarded by the `etc/.cinc-packages-installed` sentinel, so they run once per builder;
 remove the sentinel and re-converge to pull updates.
 
+## Toolchain hygiene: ucrt64 only
+
+The resource enforces a **ucrt64-only** invariant on every converge: any installed mingw toolchain
+other than `mingw-w64-ucrt-x86_64-*` (the msvcrt `mingw-w64-x86_64-*` set, i686, clang) is removed
+with `pacman -Rns`. `pacman -S --needed` only ever adds packages, so without this an adopted,
+hand-grown builder keeps every toolchain it accumulated. A second toolchain roughly doubles the
+DLL footprint, which exhausts the rebase address window (`rebase: Too many DLLs for available
+address space`) and destabilizes native-gem link steps — the failure surfaces as a silent
+`collect2.exe: error: ld returned 116 exit status` with no linker diagnostic.
+
+## Rebase
+
+After the upgrade and toolchain install, the resource reaps any process still holding
+`msys-2.0.dll` and runs `autorebase.bat` once (sentinel: `etc/.cinc-rebased`). The mass
+upgrade/install shifts hundreds of DLL base addresses, and the runtime reaping between upgrade
+passes can interrupt pacman's own rebase hooks; left inconsistent, that state later produces fork
+failures and the same silent `ld returned 116` link errors under load. The sentinel is written only
+when the rebase succeeds, so a failed rebase retries on the next converge. `autorebase.bat` must
+run from the Windows shell (not an MSYS2 shell), which is how the resource invokes it.
+
+## Maintenance: repair by re-converge, not by hand
+
+Running ad-hoc `pacman` on a live builder is how installs drift into the partial-upgrade and
+DLL-bloat failure modes above. The supported repair path for a degraded MSYS2 is `action :remove`
+followed by a re-converge (~15 minutes), which rebuilds the toolchain from a verified base into a
+known-good, freshly rebased state.
+
 ## How gcc is controlled
 
 The MSYS2 base archive contains only the MSYS2 runtime — **never gcc**. The ucrt64 compiler is
@@ -78,6 +105,12 @@ Control comes from two levers:
    fresh builders, host the specific `.pkg.tar.zst` files (these usually already exist in
    `C:\msys64\var\cache\pacman\pkg` on a working builder) and pass them here. They are installed
    with `pacman -U` before the live `pacman -S`, and the freeze keeps them in place.
+
+For a fleet, prefer the pin over the freeze alone: the freeze locks whatever bleeding-edge
+gcc/binutils the mirror shipped on each builder's converge day, so two builders provisioned weeks
+apart run different compilers. Pinning a validated set makes every builder identical and makes a
+compiler upgrade an explicit, reviewable change. (A just-released binutils was the prime suspect
+in a run of silent `ld returned 116` native-gem link failures.)
 
 ## Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -388,6 +388,21 @@ module CincOmnibus
         shell_out('tasklist /nh').stdout.match?(/gpg-agent\.exe|dirmngr\.exe/i)
       end
 
+      # True when any mingw toolchain other than ucrt64 (msvcrt/i686/clang)
+      # is installed.
+      def msys2_foreign_toolchains_present?
+        shell_out(msys2_shell(%(pacman -Qq | grep -E "^mingw-w64-" | grep -qvE "^mingw-w64-ucrt-x86_64-"))).exitstatus.zero?
+      end
+
+      # Sentinel written after a successful post-provisioning rebase.
+      def msys2_rebased_sentinel
+        windows_safe_path_join(new_resource.install_dir, 'etc', '.cinc-rebased')
+      end
+
+      def msys2_rebased?
+        ::File.exist?(msys2_rebased_sentinel)
+      end
+
       # PATH entries for the Windows load shim: tools the omnibus toolchain
       # shells out to (WiX, 7-Zip, Windows SDK, Git, MSYS2) but doesn't add itself.
       def windows_path_entries(install_dir = default_toolchain_install_dir)

--- a/resources/msys2.rb
+++ b/resources/msys2.rb
@@ -102,6 +102,14 @@ action :install do
     end
   end
 
+  # Enforce ucrt64-only on every converge: extra toolchains (msvcrt/i686/clang)
+  # bloat the DLL footprint past the rebase address window and destabilize
+  # native-gem links (silent `ld returned 116`). See cinc_omnibus_msys2.md.
+  execute 'evict foreign mingw toolchains' do
+    command msys2_shell(%(pacman -Qq | grep -E "^mingw-w64-" | grep -vE "^mingw-w64-ucrt-x86_64-" | xargs -r pacman -Rns --noconfirm))
+    only_if { msys2_foreign_toolchains_present? }
+  end
+
   # Optional pin/rollback: install exact .pkg.tar.zst files (paths or URLs)
   # before the live install so the freeze below keeps them in place.
   unless new_resource.pinned_packages.empty?
@@ -117,6 +125,21 @@ action :install do
   execute 'install msys2 packages' do
     command msys2_shell("pacman -S --needed --noconfirm #{new_resource.packages.join(' ')} && touch /etc/.cinc-packages-installed")
     creates installed
+  end
+
+  # Rebase once after all package operations (the reaped upgrade passes can
+  # leave pacman's rebase hooks unrun). autorebase.bat must run from cmd with
+  # no msys2 processes holding DLLs; `&&` writes the sentinel only on success
+  # so a failed rebase retries on the next converge.
+  execute 'reap msys2 processes before rebase' do
+    command 'taskkill /F /FI "MODULES eq msys-2.0.dll"'
+    returns [0, 128] # 128 = nothing matched
+    not_if { msys2_rebased? }
+  end
+
+  execute 'rebase msys2' do
+    command %("#{windows_safe_path_join(new_resource.install_dir, 'autorebase.bat')}" && type nul > "#{msys2_rebased_sentinel}")
+    creates msys2_rebased_sentinel
   end
 
   # Freeze the compiler against `pacman -Syu`. Must run AFTER install:

--- a/spec/unit/resources/msys2_spec.rb
+++ b/spec/unit/resources/msys2_spec.rb
@@ -6,11 +6,12 @@ describe 'cinc_omnibus_msys2' do
   step_into :cinc_omnibus_msys2
   platform 'windows'
 
-  # Stub the gpg key guard, the daemon-present guard, and the mirror-listing
-  # HTTP GET (no network).
+  # Stub the gpg key guard, the daemon-present guard, the foreign-toolchain
+  # guard, and the mirror-listing HTTP GET (no network).
   before do
     stub_command(/--list-keys/).and_return(false)
     allow_any_instance_of(CincOmnibus::Cookbook::Helpers).to receive(:msys2_gpg_daemons_running?).and_return(true)
+    allow_any_instance_of(CincOmnibus::Cookbook::Helpers).to receive(:msys2_foreign_toolchains_present?).and_return(true)
     allow_any_instance_of(Chef::HTTP::Simple).to receive(:get)
       .and_return('msys2-base-x86_64-20250830.sfx.exe msys2-base-x86_64-20260611.sfx.exe')
   end
@@ -71,6 +72,18 @@ describe 'cinc_omnibus_msys2' do
     end
 
     it { is_expected.to_not run_execute('install pinned msys2 packages') }
+
+    it 'evicts non-ucrt64 mingw toolchains (msvcrt/i686/clang)' do
+      expect(chef_run).to run_execute('evict foreign mingw toolchains')
+        .with(command: /grep -vE "\^mingw-w64-ucrt-x86_64-" \| xargs -r pacman -Rns --noconfirm/)
+    end
+
+    it 'reaps msys2 processes then rebases after the toolchain install' do
+      expect(chef_run).to run_execute('reap msys2 processes before rebase')
+        .with(command: /taskkill .*MODULES eq msys-2\.0\.dll/, returns: [0, 128])
+      expect(chef_run).to run_execute('rebase msys2')
+        .with(command: /autorebase\.bat.* && type nul > .*\.cinc-rebased/)
+    end
 
     it 'reaps the gpg-agent/dirmngr daemons so the converge can return' do
       expect(chef_run).to run_execute('stop msys2 gpg daemons')


### PR DESCRIPTION
Hardens Windows builders against two MSYS2 failure modes hit in
production: a second mingw toolchain bloats the DLL footprint past the
rebase address window ("Too many DLLs for available address space"), and
inconsistent DLL bases surface as silent `collect2.exe: error: ld
returned 116 exit status` native-gem link failures with no diagnostic.

- Evict any installed non-ucrt64 mingw toolchain (msvcrt/i686/clang) on
  every converge, so adopted hand-grown builders converge to the same
  invariant as freshly provisioned ones
- Reap msys2 processes and run autorebase.bat once after all package
  operations; the sentinel is written only on success so a failed
  rebase retries on the next converge
- Document both failure modes, the repair-by-re-converge maintenance
  path, and recommend pinned_packages over the IgnorePkg freeze alone
  for fleet-wide compiler determinism

Signed-off-by: Lance Albertson <lance@osuosl.org>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
