### PR TITLE
feat: Fix FreeBSD OpenSSL trust and add runner sudo grants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,9 @@ project's CI; the cookbook's Kitchen suites stay x86_64-only.
 | FreeBSD | `pkg` packages + `omnibus-toolchain` self-extracting `.sh` |
 | Windows | `omnibus-toolchain` `.msi` (build deps live in the runner image) |
 
+On FreeBSD the cookbook links `/usr/local/openssl/cert.pem` (the ports OpenSSL's `OPENSSLDIR`, which
+`ca_root_nss` leaves empty) to the `ca_root_nss` bundle, so RVM-built rubies can verify TLS.
+
 On macOS the cookbook also creates compatibility symlinks in `/usr/local/bin` so that the
 canonical autotools names resolve against Homebrew's renamed binaries: `libtoolize` →
 `glibtoolize` always, and on Apple Silicon also `pkg-config` → Homebrew's `pkg-config` shim

--- a/documentation/cinc_omnibus_builder.md
+++ b/documentation/cinc_omnibus_builder.md
@@ -43,6 +43,7 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
 | `manage_gitlab_runner` | true, false | `true` | Non-Linux only. Whether to install and manage the GitLab Runner via the [`cinc_omnibus_gitlab_runner`](cinc_omnibus_gitlab_runner.md) resource. No-op on Linux. |
 | `manage_gitlab_runner_service` | true, false | `true` | Whether the runner service is set up and started (passed to `cinc_omnibus_gitlab_runner`). |
 | `manage_gitlab_runner_signing` | true, false | `true` | macOS only. Whether to re-sign the runner binary with a fixed identity for a durable TCC grant (passed to `cinc_omnibus_gitlab_runner`). |
+| `manage_gitlab_runner_sudoers` | true, false | `true` | macOS and FreeBSD. Whether to grant the account the runner runs as passwordless sudo via a `sudoers.d` drop-in (passed to `cinc_omnibus_gitlab_runner`). |
 | `gitlab_runner_version` | String, nil | `nil` | GitLab Runner version to install (passed to `cinc_omnibus_gitlab_runner`). |
 
 ## Platform notes
@@ -58,7 +59,11 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
   (`/opt/homebrew`) isn't on the default omnibus PATH. Because the build user's primary group is
   set to `omnibus`, it also keeps the user in the `com.apple.access_ssh` group so SSH logins keep
   working when Remote Login is limited to specific users.
-* **FreeBSD:** installs `pkg` prerequisites and the `omnibus-toolchain` self-extracting `.sh`.
+* **FreeBSD:** installs `pkg` prerequisites and the `omnibus-toolchain` self-extracting `.sh`. Also
+  links `/usr/local/openssl/cert.pem` → `/usr/local/share/certs/ca-root-nss.crt`: the ports OpenSSL
+  compiles in `/usr/local/openssl` as its `OPENSSLDIR`, but `ca_root_nss` only populates
+  `/usr/local/etc/ssl` and `/usr/local/share/certs`, so anything linked against it (an RVM-built
+  Ruby, notably) fails TLS verification with "unable to get local issuer certificate".
 * **Windows:** installs chocolatey and the build tools it manages (WiX, 7-Zip, the Windows SDK,
   Git), installs the `omnibus-toolchain` `.msi` to `C:\cinc-project\omnibus-toolchain`, skips the
   omnibus user/group creation, and writes `load-omnibus-toolchain.ps1` instead of the bash shim.

--- a/documentation/cinc_omnibus_gitlab_runner.md
+++ b/documentation/cinc_omnibus_gitlab_runner.md
@@ -25,6 +25,7 @@ builds run in Docker containers and the runner lives on the Docker host, not the
 | `instance_name` | String | name property | Resource name. |
 | `version` | String, nil | `nil` (package default / latest) | Version to pass to the platform package provider. Best-effort on Homebrew (which tracks the latest formula). |
 | `manage_service` | true, false | `true` | Whether to set up and start the runner service (macOS LaunchAgent, FreeBSD rc.d, Windows service). |
+| `manage_sudoers` | true, false | `true` | macOS and FreeBSD: drop a sudoers file granting the account the runner runs as passwordless sudo — `/etc/sudoers.d/<build_user>` on macOS, `/usr/local/etc/sudoers.d/gitlab-runner` on FreeBSD (where `sudo` is also installed). |
 | `build_user` | String | `'omnibus'` | macOS only: the user whose GUI session the LaunchAgent runs in, and who owns the signing keychain. |
 | `build_user_home` | String | platform-specific | Home of `build_user`. |
 | `manage_macos_signing` | true, false | `true` | macOS only: re-sign the binary with a fixed self-signed identity so the Automation/TCC grant survives upgrades (see below). |
@@ -50,6 +51,13 @@ builds run in Docker containers and the runner lives on the Docker host, not the
   only (re)starts it when `build_user` owns the console — enable **auto-login** for `build_user` so
   it's logged in across reboots and converges. On a host with no one logged in, the start step is
   skipped (rather than failing the run) and the agent loads at next login.
+* **Sudo:** writes `/etc/sudoers.d/<build_user>` (mode `0440`, validated with `visudo -cf`) granting
+  `<build_user> ALL = (ALL) NOPASSWD:ALL`. The build script renames `/opt/omnibus-toolchain` aside
+  and re-creates the install dir through `sudo` from a non-interactive job, so that account cannot be
+  prompted for a password. The grant is named for `build_user` (the account the LaunchAgent runs as),
+  unlike FreeBSD where the port's own `gitlab-runner` user is the one that needs it. `sudo` ships
+  with macOS and `/etc/sudoers` already includes `sudoers.d`, so nothing is installed. Set
+  `manage_sudoers false` to opt out.
 * **The TCC "control Finder" problem and the fix.** That Finder AppleScript needs the macOS TCC
   **Automation** permission (`gitlab-runner` → Finder). Homebrew ships `gitlab-runner` as a Go
   binary that is ad-hoc signed at build time, so its code-signing identity (cdhash) changes on every
@@ -95,6 +103,10 @@ builds run in Docker containers and the runner lives on the Docker host, not the
   is no GitLab-official FreeBSD package, and **no upstream `freebsd-arm64` binary** — rely on the
   port (built for the host arch) on arm64 hosts.
 * **Service:** enabled and started via rc.d (`gitlab_runner`).
+* **Sudo:** installs `sudo` and writes `/usr/local/etc/sudoers.d/gitlab-runner` (mode `0440`,
+  validated with `visudo -cf`) granting `gitlab-runner ALL = (ALL) NOPASSWD:ALL`. The omnibus build
+  renames `/opt/omnibus-toolchain` aside and runs omnibus itself as root from a non-interactive job,
+  so the runner user cannot be prompted for a password. Set `manage_sudoers false` to opt out.
 
 ### Windows
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -139,6 +139,7 @@ module CincOmnibus
             autoconf
             automake
             bash
+            ca_root_nss
             gcc
             git
             libffi

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -33,6 +33,7 @@ property :msys2_verify_signature, [true, false], default: true
 property :manage_gitlab_runner, [true, false], default: true
 property :manage_gitlab_runner_service, [true, false], default: true
 property :manage_gitlab_runner_signing, [true, false], default: true
+property :manage_gitlab_runner_sudoers, [true, false], default: true
 property :gitlab_runner_version, [String, nil]
 
 default_action :create
@@ -254,6 +255,18 @@ action :create do
     end
   end
 
+  if freebsd?
+    # The ports OpenSSL's OPENSSLDIR is /usr/local/openssl, but ca_root_nss only
+    # populates /usr/local/etc/ssl and /usr/local/share/certs. Without a cert.pem
+    # there, anything linked against it (an RVM-built ruby, notably) fails TLS
+    # verification with "unable to get local issuer certificate".
+    directory '/usr/local/openssl'
+
+    link '/usr/local/openssl/cert.pem' do
+      to '/usr/local/share/certs/ca-root-nss.crt'
+    end
+  end
+
   # Install the GitLab Runner on non-Linux builders (Linux runners live on the
   # Docker host). Registration stays manual; this never runs `register`.
   if new_resource.manage_gitlab_runner && !linux?
@@ -263,6 +276,7 @@ action :create do
       version new_resource.gitlab_runner_version
       manage_service new_resource.manage_gitlab_runner_service
       manage_macos_signing new_resource.manage_gitlab_runner_signing
+      manage_sudoers new_resource.manage_gitlab_runner_sudoers
     end
   end
 end
@@ -314,6 +328,7 @@ action :remove do
       build_user new_resource.build_user
       build_user_home new_resource.build_user_home
       manage_service new_resource.manage_gitlab_runner_service
+      manage_sudoers new_resource.manage_gitlab_runner_sudoers
       remove_package new_resource.remove_packages
       action :remove
     end

--- a/resources/gitlab_runner.rb
+++ b/resources/gitlab_runner.rb
@@ -10,6 +10,7 @@ include CincOmnibus::Cookbook::Helpers
 property :instance_name, String, name_property: true
 property :version, [String, nil]
 property :manage_service, [true, false], default: true
+property :manage_sudoers, [true, false], default: true
 property :build_user, String, default: 'omnibus'
 property :build_user_home, String, default: lazy { default_build_user_home }
 
@@ -45,6 +46,20 @@ action :create do
 
     package 'gitlab-runner' do
       version new_resource.version if new_resource.version
+    end
+
+    # The build script renames /opt/omnibus-toolchain aside and re-creates the
+    # install_dir through sudo from a non-interactive job, so the account the
+    # LaunchAgent runs as needs passwordless sudo. sudo ships with macOS, and
+    # /etc/sudoers already carries the sudoers.d includedir.
+    if new_resource.manage_sudoers
+      file "/etc/sudoers.d/#{build_user}" do
+        content "#{build_user} ALL = (ALL) NOPASSWD:ALL\n"
+        owner 'root'
+        group 'wheel'
+        mode '0440'
+        verify 'visudo -cf %{path}'
+      end
     end
 
     if new_resource.manage_macos_signing
@@ -139,6 +154,21 @@ action :create do
       version new_resource.version if new_resource.version
     end
 
+    # The build jobs shell out to sudo from a non-interactive runner session —
+    # /opt/omnibus-toolchain is renamed aside and omnibus itself runs as root —
+    # so the port's gitlab-runner user needs passwordless sudo.
+    if new_resource.manage_sudoers
+      package 'sudo'
+
+      file '/usr/local/etc/sudoers.d/gitlab-runner' do
+        content "gitlab-runner ALL = (ALL) NOPASSWD:ALL\n"
+        owner 'root'
+        group 'wheel'
+        mode '0440'
+        verify 'visudo -cf %{path}'
+      end
+    end
+
     service 'gitlab_runner' do
       action [:enable, :start]
     end if new_resource.manage_service
@@ -200,6 +230,10 @@ action :remove do
       action :delete
     end
 
+    file "/etc/sudoers.d/#{build_user}" do
+      action :delete
+    end if new_resource.manage_sudoers
+
     package 'gitlab-runner' do
       action :remove
     end if new_resource.remove_package
@@ -207,6 +241,10 @@ action :remove do
     service 'gitlab_runner' do
       action [:stop, :disable]
     end if new_resource.manage_service
+
+    file '/usr/local/etc/sudoers.d/gitlab-runner' do
+      action :delete
+    end if new_resource.manage_sudoers
 
     package 'gitlab-runner' do
       action :remove

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -203,11 +203,13 @@ describe 'cinc_omnibus_builder' do
     end
 
     it { expect { chef_run }.to_not raise_error }
-    %w(autoconf automake gcc git libffi libtool libyaml openssl pkgconf readline).each do |pkg|
+    %w(autoconf automake ca_root_nss gcc git libffi libtool libyaml openssl pkgconf readline).each do |pkg|
       it { is_expected.to install_package(pkg) }
     end
     it { is_expected.to create_template('/home/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to_not create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
+    it { is_expected.to create_directory('/usr/local/openssl') }
+    it { is_expected.to create_link('/usr/local/openssl/cert.pem').with(to: '/usr/local/share/certs/ca-root-nss.crt') }
     it { is_expected.to create_cinc_omnibus_gitlab_runner('default') }
   end
 

--- a/spec/unit/resources/gitlab_runner_spec.rb
+++ b/spec/unit/resources/gitlab_runner_spec.rb
@@ -57,6 +57,60 @@ describe 'cinc_omnibus_gitlab_runner' do
         user: 'omnibus'
       )
     end
+
+    # The LaunchAgent runs as build_user, so the grant is named for that account
+    # rather than for gitlab-runner as on FreeBSD.
+    it 'grants the build user passwordless sudo' do
+      is_expected.to create_file('/etc/sudoers.d/omnibus').with(
+        content: "omnibus ALL = (ALL) NOPASSWD:ALL\n",
+        owner: 'root',
+        group: 'wheel',
+        mode: '0440'
+      )
+    end
+
+    # sudo is part of the macOS base system; nothing to install.
+    it { is_expected.to_not install_package('sudo') }
+  end
+
+  context 'on macos with a custom build user' do
+    platform 'mac_os_x', '12'
+
+    before do
+      stub_guard(:gitlab_runner_service_started?, false)
+      stub_guard(:gitlab_runner_console_owned_by_build_user?, true)
+    end
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        build_user 'builder'
+        manage_macos_signing false
+      end
+    end
+
+    it 'names the sudoers drop-in for that user' do
+      is_expected.to create_file('/etc/sudoers.d/builder').with(
+        content: "builder ALL = (ALL) NOPASSWD:ALL\n"
+      )
+    end
+  end
+
+  context 'on macos with manage_sudoers false' do
+    platform 'mac_os_x', '12'
+
+    before do
+      stub_guard(:gitlab_runner_service_started?, false)
+      stub_guard(:gitlab_runner_console_owned_by_build_user?, true)
+    end
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        manage_sudoers false
+        manage_macos_signing false
+      end
+    end
+
+    it { is_expected.to_not create_file('/etc/sudoers.d/omnibus') }
   end
 
   context 'on macos intel' do
@@ -107,6 +161,31 @@ describe 'cinc_omnibus_gitlab_runner' do
     it { is_expected.to start_service('gitlab_runner') }
     # No macOS signing/AppleScript on FreeBSD.
     it { is_expected.to_not run_execute('resign gitlab-runner') }
+
+    # The build renames /opt/omnibus-toolchain aside and runs omnibus as root.
+    it { is_expected.to install_package('sudo') }
+
+    it 'grants the runner user passwordless sudo' do
+      is_expected.to create_file('/usr/local/etc/sudoers.d/gitlab-runner').with(
+        content: "gitlab-runner ALL = (ALL) NOPASSWD:ALL\n",
+        owner: 'root',
+        group: 'wheel',
+        mode: '0440'
+      )
+    end
+  end
+
+  context 'on freebsd with manage_sudoers false' do
+    platform 'freebsd', '12.1'
+
+    recipe do
+      cinc_omnibus_gitlab_runner 'default' do
+        manage_sudoers false
+      end
+    end
+
+    it { is_expected.to_not create_file('/usr/local/etc/sudoers.d/gitlab-runner') }
+    it { is_expected.to_not install_package('sudo') }
   end
 
   context 'on windows' do
@@ -146,6 +225,7 @@ describe 'cinc_omnibus_gitlab_runner' do
     it { is_expected.to run_execute('stop gitlab-runner service') }
     it { is_expected.to run_execute('delete gitlab-runner signing keychain') }
     it { is_expected.to delete_file('/Users/omnibus/finder-auth-flow.scpt') }
+    it { is_expected.to delete_file('/etc/sudoers.d/omnibus') }
     it { is_expected.to_not remove_package('gitlab-runner') }
   end
 
@@ -160,6 +240,7 @@ describe 'cinc_omnibus_gitlab_runner' do
 
     it { is_expected.to disable_service('gitlab_runner') }
     it { is_expected.to stop_service('gitlab_runner') }
+    it { is_expected.to delete_file('/usr/local/etc/sudoers.d/gitlab-runner') }
     # Package removal is opt-in.
     it { is_expected.to_not remove_package('gitlab-runner') }
   end

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -151,6 +151,7 @@ control 'default' do
     packages = %w(
       autoconf
       automake
+      ca_root_nss
       gcc
       git
       libffi
@@ -304,6 +305,21 @@ control 'default' do
         describe command 'dseditgroup -o checkmember -m omnibus com.apple.access_ssh' do
           its('exit_status') { should eq 0 }
         end
+      end
+    end
+
+    # The ports OpenSSL reads /usr/local/openssl/cert.pem, which ca_root_nss
+    # does not create; without it TLS verification fails against the trust store.
+    if os_name == 'freebsd'
+      describe file('/usr/local/openssl/cert.pem') do
+        it { should be_symlink }
+        its('link_path') { should eq '/usr/local/share/certs/ca-root-nss.crt' }
+      end
+
+      # /usr/bin/openssl is base (OPENSSLDIR /etc/ssl) and would pass regardless;
+      # the ports binary is the one omnibus builds link against.
+      describe command '/usr/local/bin/openssl s_client -connect rubygems.cinc.sh:443 -verify_return_error </dev/null' do
+        its('exit_status') { should eq 0 }
       end
     end
   end


### PR DESCRIPTION
## Description

Two FreeBSD/macOS builder-provisioning gaps found while adding FreeBSD 15 to the [omnibus-toolchain](https://gitlab.com/cinc-project/distribution/omnibus-toolchain) build matrix.

**FreeBSD TLS trust.** The `package:freebsd-15` job failed installing gems:

```
ERROR:  SSL verification error at depth 2: unable to get local issuer certificate (20)
ERROR:  You must add /C=US/O=Internet Security Research Group/CN=ISRG Root X1 to your local trusted store
Error fetching https://rubygems.cinc.sh: ... certificate verify failed
```

RVM compiles Ruby against the ports OpenSSL, which compiles in `/usr/local/openssl` as its `OPENSSLDIR`. `ca_root_nss` only populates `/usr/local/etc/ssl` and `/usr/local/share/certs`, so that directory has no `cert.pem` and verification fails. Confirmed on the affected host:

```
# ruby -ropenssl -e 'f=OpenSSL::X509::DEFAULT_CERT_FILE; puts f; puts File.exist?(f)'
/usr/local/openssl/cert.pem
false
```

**Runner sudo.** The omnibus build renames `/opt/omnibus-toolchain` aside and (on FreeBSD) runs omnibus as root, from a non-interactive job that cannot answer a password prompt.

## Changes

- Install `ca_root_nss` on FreeBSD and link `/usr/local/openssl/cert.pem` to its bundle
- Add `manage_sudoers` to `cinc_omnibus_gitlab_runner`: `/etc/sudoers.d/<build_user>` on macOS, `/usr/local/etc/sudoers.d/gitlab-runner` on FreeBSD (which also installs `sudo`, absent from base). Both are `0440`, validated with `visudo -cf`, and removed on `:remove`
- Pass through from `cinc_omnibus_builder` as `manage_gitlab_runner_sudoers`
- Unit specs for both, plus the cert.pem link and a live TLS handshake through the ports `openssl` in the integration profile

The sudoers grant is named for `build_user` on macOS (the account the LaunchAgent runs as) and for `gitlab-runner` on FreeBSD (the user the port creates). Neither is written on Linux (the runner lives on the Docker host) or Windows.

## Testing

`rspec` 149 examples / 0 failures; `cookstyle` clean; `cinc-auditor check` valid.

The FreeBSD Kitchen suites set `manage_gitlab_runner false`, so the sudoers drop-in has unit coverage only — the cert.pem link is covered in the integration profile since it comes from the builder path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)