### PR TITLE
fix(freebsd): install ccache and put its wrappers on PATH

### DIFF
--- a/documentation/cinc_omnibus_builder.md
+++ b/documentation/cinc_omnibus_builder.md
@@ -63,7 +63,9 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
   links `/usr/local/openssl/cert.pem` → `/usr/local/share/certs/ca-root-nss.crt`: the ports OpenSSL
   compiles in `/usr/local/openssl` as its `OPENSSLDIR`, but `ca_root_nss` only populates
   `/usr/local/etc/ssl` and `/usr/local/share/certs`, so anything linked against it (an RVM-built
-  Ruby, notably) fails TLS verification with "unable to get local issuer certificate".
+  Ruby, notably) fails TLS verification with "unable to get local issuer certificate". The load
+  shim prepends `/usr/local/libexec/ccache` to `PATH` so builds pick up the `ccache` port's
+  compiler wrappers, matching what ports' `bsd.ccache.mk` does.
 * **Windows:** installs chocolatey and the build tools it manages (WiX, 7-Zip, the Windows SDK,
   Git), installs the `omnibus-toolchain` `.msi` to `C:\cinc-project\omnibus-toolchain`, skips the
   omnibus user/group creation, and writes `load-omnibus-toolchain.ps1` instead of the bash shim.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -140,6 +140,7 @@ module CincOmnibus
             automake
             bash
             ca_root_nss
+            ccache
             gcc
             git
             libffi
@@ -217,6 +218,12 @@ module CincOmnibus
 
       def omnibus_env
         node.run_state[:omnibus_env] ||= Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      # Where the ccache port drops its cc/gcc/c++ symlinks: ports' bsd.ccache.mk
+      # uses ${LOCALBASE}/libexec/ccache, and LOCALBASE is /usr/local.
+      def freebsd_ccache_wrapper_dir
+        '/usr/local/libexec/ccache'
       end
 
       # The load-shim variables and patch content helpers below back files

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -61,6 +61,9 @@ action_class do
       env['BASH_ENV'] = [windows_safe_path_join(windows_msys2_install_dir, 'etc', 'bash.bashrc')]
     else
       env['PATH'] = [::File.join(install_dir, 'bin'), '/usr/local/bin']
+      # ccache's compiler wrappers live in their own dir and only take effect
+      # when it precedes the real compilers on PATH, as ports' bsd.ccache.mk does.
+      env['PATH'].unshift(freebsd_ccache_wrapper_dir) if freebsd?
     end
 
     new_resource.extra_environment.each do |key, value|

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -203,10 +203,16 @@ describe 'cinc_omnibus_builder' do
     end
 
     it { expect { chef_run }.to_not raise_error }
-    %w(autoconf automake ca_root_nss gcc git libffi libtool libyaml openssl pkgconf readline).each do |pkg|
+    %w(autoconf automake ca_root_nss ccache gcc git libffi libtool libyaml openssl pkgconf readline).each do |pkg|
       it { is_expected.to install_package(pkg) }
     end
     it { is_expected.to create_template('/home/omnibus/load-omnibus-toolchain.sh') }
+
+    it 'puts the ccache wrappers ahead of the real compilers on PATH' do
+      expect(chef_run).to render_file('/home/omnibus/load-omnibus-toolchain.sh')
+        .with_content(%r{^export PATH="/usr/local/libexec/ccache:/opt/omnibus-toolchain/bin:/usr/local/bin:\$PATH"$})
+    end
+
     it { is_expected.to_not create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
     it { is_expected.to create_directory('/usr/local/openssl') }
     it { is_expected.to create_link('/usr/local/openssl/cert.pem').with(to: '/usr/local/share/certs/ca-root-nss.crt') }

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -152,6 +152,7 @@ control 'default' do
       autoconf
       automake
       ca_root_nss
+      ccache
       gcc
       git
       libffi
@@ -320,6 +321,22 @@ control 'default' do
       # the ports binary is the one omnibus builds link against.
       describe command '/usr/local/bin/openssl s_client -connect rubygems.cinc.sh:443 -verify_return_error </dev/null' do
         its('exit_status') { should eq 0 }
+      end
+
+      # ccache only speeds builds up if its wrappers win over the real compilers,
+      # so the shim has to export that dir ahead of them.
+      describe file('/usr/local/libexec/ccache/gcc') do
+        it { should exist }
+      end
+
+      describe file("#{build_user_home}/#{shim_name}") do
+        its('content') do
+          should match(%r{^export PATH="/usr/local/libexec/ccache:#{install_dir}/bin:/usr/local/bin:\$PATH"$})
+        end
+      end
+
+      describe command "PATH='/usr/local/libexec/ccache:#{install_dir}/bin:/usr/local/bin:#{unix_path}' command -v gcc" do
+        its('stdout') { should match(%r{^/usr/local/libexec/ccache/gcc$}) }
       end
     end
   end


### PR DESCRIPTION
## Description

We forgot `ccache` in the FreeBSD build package list, so FreeBSD builders recompiled everything from scratch every run.

Installing the port alone isn't enough. FreeBSD's `devel/ccache` puts its `cc`/`gcc`/`c++` wrappers in `/usr/local/libexec/ccache`, and they only take effect when that directory precedes the real compilers on `PATH`. The non-Windows toolchain env (and therefore the `load-omnibus-toolchain.sh` shim) now prepends it on FreeBSD, so the shim exports:

```
export PATH="/usr/local/libexec/ccache:/opt/omnibus-toolchain/bin:/usr/local/bin:$PATH"
```

This mirrors what ports itself does — [`Mk/bsd.ccache.mk`](https://github.com/freebsd/freebsd-ports/blob/main/Mk/bsd.ccache.mk) defines `CCACHE_WRAPPER_PATH?= ${CCACHE_PKG_PREFIX}/libexec/ccache` (with `CCACHE_PKG_PREFIX?= ${LOCALBASE}`) and applies `PATH:= ${CCACHE_WRAPPER_PATH}:${PATH}`.

## Changes

- `libraries/helpers.rb`: add `ccache` to the FreeBSD package list; add a `freebsd_ccache_wrapper_dir` helper
- `resources/builder.rb`: prepend the wrapper dir to the toolchain `PATH` on FreeBSD
- `documentation/cinc_omnibus_builder.md`: note it under the FreeBSD platform notes
- Tests: unit expectation on the rendered shim's `PATH` line; InSpec checks that the package and wrapper exist, the shim exports the expected `PATH`, and `gcc` resolves to `/usr/local/libexec/ccache/gcc` under it

## Testing

- `chef exec rspec` — 151 examples, 0 failures
- `chef exec cookstyle` — clean on all changed files
- Integration coverage added to the FreeBSD controls; not yet run against a live FreeBSD builder

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)