### PR TITLE
fix(macos): put Homebrew git on PATH and mark the runner checkout safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,17 @@ On FreeBSD the cookbook links `/usr/local/openssl/cert.pem` (the ports OpenSSL's
 On macOS the cookbook also creates compatibility symlinks in `/usr/local/bin` so that the
 canonical autotools names resolve against Homebrew's renamed binaries: `libtoolize` →
 `glibtoolize` always, and on Apple Silicon also `pkg-config` → Homebrew's `pkg-config` shim
-(which lives outside `/usr/local/bin` when Homebrew is in `/opt/homebrew`).
+(which lives outside `/usr/local/bin` when Homebrew is in `/opt/homebrew`), plus `git` for the
+same reason.
+
+That `git` link is load-bearing, not cosmetic. Builds run `sudo -E bundle exec omnibus build`, so
+git runs as root over a build-user-owned checkout and rejects it unless the path is a
+`safe.directory`. The cookbook writes those entries into the managed `.gitconfig` (build user, and
+root's on macOS) as `<build_user_home>/builds/*`, which keeps the runner-specific token out of the
+value — but a trailing `/*` needs git 2.46+, and Apple's `/usr/bin/git` is 2.32.1, old enough to
+predate both that and the `SUDO_UID` bypass git 2.36 added. Intel picks up Homebrew's git from
+`/usr/local/bin` by accident of the prefix; Apple Silicon needs the link, and without it `git
+describe` fails and packages version as `0.0.0` without failing the job.
 
 ## GitLab Runner
 

--- a/documentation/cinc_omnibus_builder.md
+++ b/documentation/cinc_omnibus_builder.md
@@ -32,6 +32,8 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
 | `ruby_docker_copy_patch_path` | String | `'/usr/local/share/ruby-docker-copy-patch.rb'` | Path for the Docker copy-file Ruby patch. |
 | `manage_ruby_docker_copy_patch` | true, false | `true` | Whether to write the Ruby Docker copy-file patch. No-op on non-Linux platforms. |
 | `manage_debian_arm_links` | true, false | `true` | Whether to create Debian ARM compatibility links on Debian versions older than 12. |
+| `git_safe_directories` | Array | `["<build_user_home>/builds/*"]` (empty on Windows) | Paths written as `safe.directory` entries in the managed `.gitconfig`, so git accepts the runner's checkout when the build step runs it under `sudo`. A trailing `/*` matches at any depth and needs git 2.46 or newer. |
+| `manage_root_gitconfig` | true, false | `true` | macOS only. Whether to write the same `.gitconfig` to `/var/root` as well as the build user's home. |
 | `extra_environment` | Hash | `{}` | Additional environment variables for the toolchain load shim (`load-omnibus-toolchain.sh` on Unix, `load-omnibus-toolchain.ps1` on Windows). Values may be strings or arrays. |
 | `remove_packages` | true, false | `false` | Whether `:remove` should remove configured packages. |
 | `manage_msys2` | true, false | `true` | Windows only. Whether to install and manage MSYS2 via the `cinc_omnibus_msys2` resource. |
@@ -59,6 +61,15 @@ The toolchain package is sourced from the Cinc Project's package mirror via the 
   (`/opt/homebrew`) isn't on the default omnibus PATH. Because the build user's primary group is
   set to `omnibus`, it also keeps the user in the `com.apple.access_ssh` group so SSH logins keep
   working when Remote Login is limited to specific users.
+
+  Apple Silicon also gets `/usr/local/bin/git` → Homebrew's `git`, for the same PATH reason.
+  Builds run `sudo -E bundle exec omnibus build`, so git runs as root over a checkout the build
+  user owns and refuses it unless the path is a `safe.directory`. Apple's `/usr/bin/git` (2.32.1)
+  is too old to honor either the `safe.directory` values that survive a runner re-registration
+  (only exact paths work — not `*`, not a trailing `/*`) or the `SUDO_UID` bypass git 2.36 added
+  for exactly this case, so Intel — which reaches Homebrew's git through `/usr/local/bin` for
+  free — worked while Apple Silicon silently produced `0.0.0` packages. Without a git new enough
+  for it, `git describe` fails and omnibus falls back to that version.
 * **FreeBSD:** installs `pkg` prerequisites and the `omnibus-toolchain` self-extracting `.sh`. Also
   links `/usr/local/openssl/cert.pem` → `/usr/local/share/certs/ca-root-nss.crt`: the ports OpenSSL
   compiles in `/usr/local/openssl` as its `OPENSSLDIR`, but `ca_root_nss` only populates

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -226,6 +226,20 @@ module CincOmnibus
         '/usr/local/libexec/ccache'
       end
 
+      # The runner checks out under <build user home>/builds/<runner token>/...,
+      # and the build step runs it through sudo, so root's git has to accept a
+      # checkout the build user owns. The trailing /* matches at any depth, which
+      # keeps the runner-specific token out of the value. Empty on Windows: there
+      # is no sudo step, and a drive letter would need escaping in git config.
+      def default_git_safe_directories(home = default_build_user_home)
+        windows? ? [] : [::File.join(home, 'builds', '*')]
+      end
+
+      # macOS keeps root's home outside /Users.
+      def mac_root_home
+        '/var/root'
+      end
+
       # The load-shim variables and patch content helpers below back files
       # dropped by the builder action; they reference new_resource, so are only
       # valid in action context.

--- a/resources/builder.rb
+++ b/resources/builder.rb
@@ -22,6 +22,8 @@ property :mixlib_install_version, String, default: '3.12.30'
 property :ruby_docker_copy_patch_path, String, default: '/usr/local/share/ruby-docker-copy-patch.rb'
 property :manage_ruby_docker_copy_patch, [true, false], default: true
 property :manage_debian_arm_links, [true, false], default: true
+property :git_safe_directories, Array, default: lazy { default_git_safe_directories(build_user_home) }
+property :manage_root_gitconfig, [true, false], default: true
 property :extra_environment, Hash, default: {}
 property :remove_packages, [true, false], default: false
 property :manage_msys2, [true, false], default: true
@@ -182,12 +184,29 @@ action :create do
 
   env = omnibus_toolchain_environment
 
-  cookbook_file ::File.join(new_resource.build_user_home, '.gitconfig') do
-    source 'gitconfig'
+  gitconfig_variables = { safe_directories: new_resource.git_safe_directories }
+
+  template ::File.join(new_resource.build_user_home, '.gitconfig') do
+    source 'gitconfig.erb'
     cookbook 'cinc-omnibus' # not the wrapper that declares the resource
+    variables gitconfig_variables
     unless windows?
       owner new_resource.build_user
       group new_resource.build_group
+      mode '0644'
+    end
+  end
+
+  # The macOS build step runs `sudo -E`, which today keeps HOME pointed at the
+  # build user, so root reads the file above. Give root its own copy so the
+  # build keeps working if that ever stops holding.
+  if mac_os_x? && new_resource.manage_root_gitconfig
+    template ::File.join(mac_root_home, '.gitconfig') do
+      source 'gitconfig.erb'
+      cookbook 'cinc-omnibus' # not the wrapper that declares the resource
+      variables gitconfig_variables
+      owner 'root'
+      group 'wheel'
       mode '0644'
     end
   end
@@ -245,6 +264,15 @@ action :create do
       link '/usr/local/bin/pkg-config' do
         to ::File.join(brew_prefix, 'bin', 'pkg-config')
       end
+
+      # Apple's /usr/bin/git (2.32.1) predates both the sudo-aware ownership
+      # check and safe.directory globs, so `sudo -E` builds reject the runner's
+      # checkout. Intel reaches Homebrew's git through /usr/local/bin for free.
+      # Guarded: a dangling link here would shadow /usr/bin/git for every caller.
+      link '/usr/local/bin/git' do
+        to ::File.join(brew_prefix, 'bin', 'git')
+        only_if { ::File.exist?(::File.join(brew_prefix, 'bin', 'git')) }
+      end
     end
 
     # Setting the build user's primary group to `omnibus` can drop it from the
@@ -294,6 +322,10 @@ action :remove do
   file ::File.join(new_resource.build_user_home, '.gitconfig') do
     action :delete
   end
+
+  file ::File.join(mac_root_home, '.gitconfig') do
+    action :delete
+  end if mac_os_x? && new_resource.manage_root_gitconfig
 
   if windows?
     file ::File.join(new_resource.build_user_home, 'load-omnibus-toolchain.ps1') do

--- a/spec/unit/resources/builder_spec.rb
+++ b/spec/unit/resources/builder_spec.rb
@@ -31,11 +31,19 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to upgrade_chef_ingredient('omnibus-toolchain') }
     it { is_expected.to create_group('omnibus') }
     it { is_expected.to create_user('omnibus') }
-    it { is_expected.to create_cookbook_file('/home/omnibus/.gitconfig') }
+    it { is_expected.to create_template('/home/omnibus/.gitconfig') }
     it { is_expected.to create_template('/home/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to create_file('/usr/local/share/ruby-docker-copy-patch.rb') }
     # The runner lives on the Docker host on Linux, not the build node.
     it { is_expected.to_not create_cinc_omnibus_gitlab_runner('default') }
+
+    it 'marks the runner build tree safe for git' do
+      expect(chef_run).to render_file('/home/omnibus/.gitconfig')
+        .with_content(%r{^\s*directory = /home/omnibus/builds/\*$})
+    end
+
+    # Root gets its own copy on macOS only.
+    it { is_expected.to_not create_template('/var/root/.gitconfig') }
   end
 
   context 'ubuntu - ppc64le' do
@@ -135,6 +143,10 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to_not install_build_essential('cinc-omnibus') }
     it { is_expected.to_not create_group('omnibus') }
     it { is_expected.to_not create_user('omnibus') }
+
+    # No sudo step to accommodate, and a drive letter would need escaping in a
+    # git config value.
+    it { is_expected.to_not render_file('C:/omnibus/.gitconfig').with_content(/^\[safe\]$/) }
   end
 
   context 'on macos intel' do
@@ -156,6 +168,9 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to create_link('/usr/local/bin/libtoolize').with(to: '/usr/local/bin/glibtoolize') }
     it { is_expected.to create_link('/usr/local/bin/tar').with(to: '/usr/local/bin/gtar') }
     it { is_expected.to_not create_link('/usr/local/bin/pkg-config') }
+    # Homebrew's prefix already is /usr/local here, so a link would point at
+    # itself; Intel has been reaching Homebrew's git this way all along.
+    it { is_expected.to_not create_link('/usr/local/bin/git') }
     it { is_expected.to run_execute('grant build user ssh access').with(command: 'dseditgroup -o edit -a omnibus -t user com.apple.access_ssh') }
     # No SecureToken detected on the build user -> declared false, no toggle.
     it { is_expected.to create_user('omnibus').with(secure_token: false) }
@@ -189,10 +204,89 @@ describe 'cinc_omnibus_builder' do
       cinc_omnibus_builder 'default'
     end
 
+    # Homebrew git is present, as the package install earlier in the run leaves it.
+    before do
+      allow(::File).to receive(:exist?).and_call_original
+      allow(::File).to receive(:exist?).with('/opt/homebrew/bin/git').and_return(true)
+    end
+
     it { is_expected.to create_link('/usr/local/bin/libtoolize').with(to: '/opt/homebrew/bin/glibtoolize') }
     it { is_expected.to create_link('/usr/local/bin/tar').with(to: '/opt/homebrew/bin/gtar') }
     it { is_expected.to create_link('/usr/local/bin/pkg-config').with(to: '/opt/homebrew/bin/pkg-config') }
     it { is_expected.to run_execute('grant build user ssh access') }
+
+    # Apple's /usr/bin/git (2.32.1) is too old for both safe.directory globs
+    # and the SUDO_UID bypass, and /opt/homebrew/bin is off the default PATH.
+    it { is_expected.to create_link('/usr/local/bin/git').with(to: '/opt/homebrew/bin/git') }
+
+    it 'marks the runner build tree safe for the build user and for root' do
+      expect(chef_run).to create_template('/Users/omnibus/.gitconfig').with(owner: 'omnibus')
+      expect(chef_run).to create_template('/var/root/.gitconfig').with(owner: 'root', group: 'wheel')
+
+      ['/Users/omnibus/.gitconfig', '/var/root/.gitconfig'].each do |gitconfig|
+        expect(chef_run).to render_file(gitconfig)
+          .with_content(%r{^\s*directory = /Users/omnibus/builds/\*$})
+      end
+    end
+  end
+
+  context 'on macos arm64 without Homebrew git' do
+    platform 'mac_os_x', '12'
+
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(false)
+    end
+
+    before do
+      allow(::File).to receive(:exist?).and_call_original
+      allow(::File).to receive(:exist?).with('/opt/homebrew/bin/git').and_return(false)
+    end
+
+    recipe do
+      cinc_omnibus_builder 'default'
+    end
+
+    # A dangling link would shadow /usr/bin/git for every caller, including the
+    # runner's own clone step, so skipping beats breaking git outright.
+    it { is_expected.to_not create_link('/usr/local/bin/git') }
+  end
+
+  context 'on macos with manage_root_gitconfig false' do
+    platform 'mac_os_x', '12'
+
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(false)
+    end
+
+    recipe do
+      cinc_omnibus_builder 'default' do
+        manage_root_gitconfig false
+      end
+    end
+
+    it { is_expected.to create_template('/Users/omnibus/.gitconfig') }
+    it { is_expected.to_not create_template('/var/root/.gitconfig') }
+  end
+
+  context 'on macos with git_safe_directories overridden' do
+    platform 'mac_os_x', '12'
+
+    stubs_for_provider('cinc_omnibus_builder[default]') do |provider|
+      allow(provider).to receive(:mac_build_user_secure_token?).and_return(false)
+    end
+
+    recipe do
+      cinc_omnibus_builder 'default' do
+        git_safe_directories %w(/Users/omnibus/builds/tNVf4YpFJ/0/cinc-project/distribution/omnibus-software)
+      end
+    end
+
+    it 'writes exactly the configured entries' do
+      expect(chef_run).to render_file('/Users/omnibus/.gitconfig')
+        .with_content(%r{^\s*directory = /Users/omnibus/builds/tNVf4YpFJ/0/cinc-project/distribution/omnibus-software$})
+      expect(chef_run).to_not render_file('/Users/omnibus/.gitconfig')
+        .with_content(%r{directory = /Users/omnibus/builds/\*})
+    end
   end
 
   context 'on freebsd' do
@@ -335,5 +429,19 @@ describe 'cinc_omnibus_builder' do
     it { is_expected.to delete_file('/home/omnibus/load-omnibus-toolchain.sh') }
     it { is_expected.to delete_file('/usr/local/share/ruby-docker-copy-patch.rb') }
     it { is_expected.to delete_directory('/var/cache/omnibus') }
+    it { is_expected.to_not delete_file('/var/root/.gitconfig') }
+  end
+
+  context 'with remove action on macos' do
+    platform 'mac_os_x', '12'
+
+    recipe do
+      cinc_omnibus_builder 'default' do
+        action :remove
+      end
+    end
+
+    it { is_expected.to delete_file('/Users/omnibus/.gitconfig') }
+    it { is_expected.to delete_file('/var/root/.gitconfig') }
   end
 end

--- a/templates/default/gitconfig.erb
+++ b/templates/default/gitconfig.erb
@@ -20,3 +20,13 @@
   autosetuprebase = always
 [pull]
   rebase = preserve
+<% unless @safe_directories.empty? -%>
+[safe]
+  ; The build step runs `sudo -E`, so git reads this as root over a checkout
+  ; the build user owns and would otherwise refuse it, leaving `git describe`
+  ; to fail and omnibus to version the package 0.0.0. A trailing /* matches at
+  ; any depth (git 2.46+) and keeps the runner's token out of the path.
+<% @safe_directories.each do |dir| -%>
+  directory = <%= dir %>
+<% end -%>
+<% end -%>

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -313,7 +313,12 @@ control 'default' do
       if command('uname -m').stdout.strip == 'arm64'
         describe file('/usr/local/bin/git') do
           it { should be_symlink }
-          its('link_path') { should eq '/opt/homebrew/bin/git' }
+        end
+
+        # link_path resolves the whole chain, and Homebrew's own shim points
+        # into a versioned Cellar path, so assert the target we manage.
+        describe command('readlink /usr/local/bin/git') do
+          its('stdout') { should match(%r{^/opt/homebrew/bin/git$}) }
         end
       end
 

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -307,6 +307,55 @@ control 'default' do
           its('exit_status') { should eq 0 }
         end
       end
+
+      # Apple Silicon has no Homebrew bin dir on the default PATH, so without
+      # this link builds fall back to /usr/bin/git (2.32.1).
+      if command('uname -m').stdout.strip == 'arm64'
+        describe file('/usr/local/bin/git') do
+          it { should be_symlink }
+          its('link_path') { should eq '/opt/homebrew/bin/git' }
+        end
+      end
+
+      # A trailing /* in safe.directory is only honored from git 2.46 on.
+      git_version = command("PATH='/usr/local/bin:#{unix_path}' git --version").stdout[/\d+\.\d+(\.\d+)?/]
+
+      describe "git on PATH (#{git_version.inspect})" do
+        subject { Gem::Version.new(git_version || '0') }
+        it { should be >= Gem::Version.new('2.46') }
+      end
+
+      # The build step runs `sudo -E`, so git reads the build user's config as
+      # root; root keeps its own copy for the case where HOME isn't preserved.
+      safe_directory = %r{^\s*directory = /Users/omnibus/builds/\*$}
+
+      describe file("#{build_user_home}/.gitconfig") do
+        its('content') { should match safe_directory }
+      end
+
+      describe command('sudo -n cat /var/root/.gitconfig') do
+        its('exit_status') { should eq 0 }
+        its('stdout') { should match safe_directory }
+      end
+
+      # What actually broke: root's git rejected the runner's build-user-owned
+      # checkout, so `git describe` failed and omnibus versioned packages 0.0.0.
+      # SUDO_UID is cleared so this proves safe.directory works on its own,
+      # rather than git's sudo bypass masking a config that never applied.
+      probe_root = "#{build_user_home}/builds/inspec-safe-directory"
+      probe = <<~SH
+        sudo -n -u omnibus mkdir -p #{probe_root}/0/probe &&
+        sudo -n -u omnibus git init -q #{probe_root}/0/probe &&
+        sudo -n env -u SUDO_UID HOME=#{build_user_home} git -C #{probe_root}/0/probe rev-parse --git-dir
+        rc=$?
+        sudo -n rm -rf #{probe_root}
+        exit $rc
+      SH
+
+      describe command(probe) do
+        its('exit_status') { should eq 0 }
+        its('stderr') { should_not match(/dubious ownership|unsafe repository/) }
+      end
     end
 
     # The ports OpenSSL reads /usr/local/openssl/cert.pem, which ca_root_nss


### PR DESCRIPTION
## Symptom

Builds on the `macos-26-aarch64` runner fail `git describe`, so omnibus falls back to a bogus version — packages ship as `0.0.0` instead of e.g. `26.8.12-git.1.2bbbff7`. It does not fail the job, so it is easy to miss.

```
fatal: unsafe repository ('/Users/omnibus/builds/.../omnibus-software' is owned by someone else)
[BuildVersion] W | Could not extract version information from 'git describe'! Setting version to 0.0.0.
```

## Root cause

The build step is `sudo -E bundle exec omnibus build`, so git runs as **root** over a checkout the `omnibus` user owns, and refuses it unless the path is a `safe.directory`.

The delta between the two runners is the **git binary**, not any config:

| | git resolved under `sudo -E` | version |
| --- | --- | --- |
| `macos-26` (Intel) | `/usr/local/bin/git` | 2.54.0 (Homebrew) |
| `macos-26-aarch64` | `/usr/bin/git` | 2.32.1 (Apple Git-133) |

Git 2.36 added a documented bypass: running as root under sudo, git also trusts repositories owned by `SUDO_UID`. sudo sets `SUDO_UID=501` = `omnibus`, which owns the checkout — so **Intel passes with no config anywhere**. Its Homebrew prefix *is* `/usr/local`, so Homebrew's git lands on the default PATH for free. On Apple Silicon Homebrew lives in `/opt/homebrew`, which isn't, so builds fall back to Apple's git — too old for that bypass. This is the same trap the cookbook already works around for `pkg-config`.

Both hosts were checked: `/Users/omnibus/builds` is `omnibus:omnibus` on each, and neither has a `/var/root/.gitconfig`.

## What changed

- **Apple Silicon gets `/usr/local/bin/git` → `/opt/homebrew/bin/git`**, bringing it to parity with Intel (both now on Homebrew git 2.54.0). Guarded by `File.exist?`: a dangling link there would shadow `/usr/bin/git` for every caller and break the runner's own clone step, so skipping beats breaking git outright.
- **The managed `.gitconfig` moves from a static `cookbook_file` to a template** carrying a `[safe]` section. New `git_safe_directories` property defaults to `<build_user_home>/builds/*` — token-independent, so it survives a runner re-registration, and narrower than a blanket `*`.
- **Root gets its own copy** at `/var/root/.gitconfig` on macOS (`manage_root_gitconfig`). `sudo -E` preserves `HOME` today, so root already reads the build user's file, but the build shouldn't depend on that holding.
- Windows defaults to no entries — no sudo step, and a drive letter would need escaping in a git config value.

## On the `safe.directory` syntax

Apple git 2.32.1 was tested directly on the aarch64 host: **only exact paths work — both `/path/*` and a bare `*` fail** (`*` arrived in 2.35.3/2.36, trailing `/*` in 2.46). So no durable, token-independent value exists on that git at all, which is why moving to Homebrew's git is the fix rather than config alone.

The trailing `/*` was then verified to be a *recursive* prefix match, not one level: as root over a uid-1000-owned checkout at the real runner path shape, `git describe` fails with `detected dubious ownership`, and with the rendered gitconfig returns the commit. A bare directory without `/*` fails.

## Testing

- 164 unit examples pass; cookstyle clean.
- New ChefSpec coverage for the link on Apple Silicon, its absence on Intel (where it would point at itself), the guard when Homebrew git is missing, both gitconfigs and their contents, the property overrides, and `:remove`.
- InSpec gains the symlink and git-version assertions, gitconfig content checks, and a functional probe that clears `SUDO_UID` so it proves `safe.directory` works on its own rather than the sudo bypass masking a config that never applied.

## Verifying on the runners

Converge both macOS builders, then run a manual `macos26-aarch64` job on omnibus-software and confirm the `Building test <version>...` line shows a real version with no `unsafe repository` error. Worth converging Intel too — it currently passes only by accident of the `SUDO_UID` bypass, and this puts the same explicit config on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
